### PR TITLE
2.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This Tampermonkey script allows for downloading individual posts and pages from 
 ##  Installation
 1. Install the Tampermonkey browser extension: [Chrome](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en) [Firefox](https://addons.mozilla.org/en-US/firefox/addon/tampermonkey/) [Brave](https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo?hl=en)
 2. **Important:** Under the tampermonkey settings, set the **Config mode** to **Advanced** and enable the **Browser API** in **Download Mode (BETA)**.
-3. Copy the contents of [https://github.com/SkyCloudDev/ForumPostDownloader/blob/main/dist/build.js](https://github.com/SkyCloudDev/ForumPostDownloader/blob/main/dist/build.js)
+3. Copy the contents of [https://github.com/SkyCloudDev/ForumPostDownloader/blob/main/dist/build.user.js](https://github.com/SkyCloudDev/ForumPostDownloader/blob/main/dist/build.user.js)
 4. Create a new Tampermonkey script and paste the contents you copied in step 3 (build.js).
 5. Save the script (Ctrl+S).
 6. Visit any thread to verify the script installation.

--- a/build.js
+++ b/build.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const getContents = path => require('child_process').execSync(`cat ${path}`).toString('utf-8');
+const getContents = path => require('child_process').execSync(`cat ${path}`).toString();
 
 const header = getContents('./src/header.js');
 
@@ -16,4 +16,4 @@ if (!fs.existsSync('./dist')) {
 
 const data = header + includes + main;
 
-fs.writeFileSync('dist/build.js', data);
+fs.writeFileSync('dist/build.user.js', data);

--- a/dist/build.user.js
+++ b/dist/build.user.js
@@ -2695,19 +2695,21 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
       saveAs(blob, filename);
       setProcessing(false, postId);
     } else {
-      let url = URL.createObjectURL(blob);
-      GM_download({
-        url,
-        name: `${title}/#${postNumber}/generated.zip`,
-        onload: () => {
-          URL.revokeObjectURL(url);
-          blob = null;
-        },
-        onerror: response => {
-          console.log(`Error writing file ${fn} to disk. There may be more details below.`);
-          console.log(response);
-        },
-      });
+      if (postSettings.generateLog || postSettings.generateLinks) {
+        let url = URL.createObjectURL(blob);
+        GM_download({
+          url,
+          name: `${title}/#${postNumber}/generated.zip`,
+          onload: () => {
+            URL.revokeObjectURL(url);
+            blob = null;
+          },
+          onerror: response => {
+            console.log(`Error writing file ${fn} to disk. There may be more details below.`);
+            console.log(response);
+          },
+        });
+      }
     }
   } else {
     setProcessing(false, postId);

--- a/dist/build.user.js
+++ b/dist/build.user.js
@@ -6,7 +6,7 @@
 // @author x111000111
 // @author backwards
 // @description Downloads images and videos from posts
-// @version 2.3.3
+// @version 2.3.5
 // @updateURL https://github.com/SkyCloudDev/ForumPostDownloader/raw/main/dist/build.user.js
 // @downloadURL https://github.com/SkyCloudDev/ForumPostDownloader/raw/main/dist/build.user.js
 // @icon https://simp4.jpg.church/simpcityIcon192.png
@@ -2654,7 +2654,6 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
   h.hide(statusLabel);
   h.hide(filePB);
   h.hide(totalPB);
-  window.logs = window.logs.filter(l => l.postId !== postId);
 
   if (!isFF) {
     setProcessing(false, postId);
@@ -2725,6 +2724,8 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
 
     callbacks && callbacks.onComplete && callbacks.onComplete(totalDownloadable, completed);
   }
+
+  window.logs = window.logs.filter(l => l.postId !== postId);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forum-post-downloader",
-  "version": "2.3.3",
+  "version": "2.3.5",
   "description": "Downloads images and videos from all the popular hosts.",
   "scripts": {
     "build": "node build.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forum-post-downloader",
-  "version": "2.2.6",
+  "version": "2.3.3",
   "description": "Downloads images and videos from all the popular hosts.",
   "scripts": {
     "build": "node build.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,875 @@
+lockfileVersion: 5.4
+
+specifiers:
+  chokidar-cli: ^3.0.0
+  concurrently: ^7.5.0
+  express: ^4.18.2
+  prettier: ^2.7.1
+
+devDependencies:
+  chokidar-cli: 3.0.0
+  concurrently: 7.6.0
+  express: 4.18.2
+  prettier: 2.8.3
+
+packages:
+
+  /accepts/1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+    dev: true
+
+  /ansi-regex/4.1.1:
+    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /ansi-regex/5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /ansi-styles/3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
+    dev: true
+
+  /ansi-styles/4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      color-convert: 2.0.1
+    dev: true
+
+  /anymatch/3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+    dev: true
+
+  /array-flatten/1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+    dev: true
+
+  /binary-extensions/2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /body-parser/1.20.1:
+    resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.11.0
+      raw-body: 2.5.1
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /braces/3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.0.1
+    dev: true
+
+  /bytes/3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /call-bind/1.0.2:
+    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
+    dependencies:
+      function-bind: 1.1.1
+      get-intrinsic: 1.2.0
+    dev: true
+
+  /camelcase/5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /chalk/4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+    dev: true
+
+  /chokidar-cli/3.0.0:
+    resolution: {integrity: sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==}
+    engines: {node: '>= 8.10.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.3
+      lodash.debounce: 4.0.8
+      lodash.throttle: 4.1.1
+      yargs: 13.3.2
+    dev: true
+
+  /chokidar/3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /cliui/5.0.0:
+    resolution: {integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==}
+    dependencies:
+      string-width: 3.1.0
+      strip-ansi: 5.2.0
+      wrap-ansi: 5.1.0
+    dev: true
+
+  /cliui/8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
+
+  /color-convert/1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+    dev: true
+
+  /color-convert/2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+    dependencies:
+      color-name: 1.1.4
+    dev: true
+
+  /color-name/1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    dev: true
+
+  /color-name/1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
+
+  /concurrently/7.6.0:
+    resolution: {integrity: sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==}
+    engines: {node: ^12.20.0 || ^14.13.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      date-fns: 2.29.3
+      lodash: 4.17.21
+      rxjs: 7.8.0
+      shell-quote: 1.7.4
+      spawn-command: 0.0.2-1
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.6.2
+    dev: true
+
+  /content-disposition/0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /content-type/1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /cookie-signature/1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+    dev: true
+
+  /cookie/0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /date-fns/2.29.3:
+    resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
+    engines: {node: '>=0.11'}
+    dev: true
+
+  /debug/2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: true
+
+  /decamelize/1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /depd/2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /destroy/1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dev: true
+
+  /ee-first/1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: true
+
+  /emoji-regex/7.0.3:
+    resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
+    dev: true
+
+  /emoji-regex/8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    dev: true
+
+  /encodeurl/1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /escalade/3.1.1:
+    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /escape-html/1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: true
+
+  /etag/1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /express/4.18.2:
+    resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
+    engines: {node: '>= 0.10.0'}
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.1
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.5.0
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.2.0
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.1
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.7
+      proxy-addr: 2.0.7
+      qs: 6.11.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.18.0
+      serve-static: 1.15.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /fill-range/7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
+    dev: true
+
+  /finalhandler/1.2.0:
+    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /find-up/3.0.0:
+    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
+    engines: {node: '>=6'}
+    dependencies:
+      locate-path: 3.0.0
+    dev: true
+
+  /forwarded/0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /fresh/0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /function-bind/1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: true
+
+  /get-caller-file/2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dev: true
+
+  /get-intrinsic/1.2.0:
+    resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
+    dependencies:
+      function-bind: 1.1.1
+      has: 1.0.3
+      has-symbols: 1.0.3
+    dev: true
+
+  /glob-parent/5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: true
+
+  /has-flag/4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /has-symbols/1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /has/1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      function-bind: 1.1.1
+    dev: true
+
+  /http-errors/2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+    dev: true
+
+  /iconv-lite/0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: true
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
+
+  /ipaddr.js/1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+    dev: true
+
+  /is-binary-path/2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.2.0
+    dev: true
+
+  /is-extglob/2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-fullwidth-code-point/2.0.0:
+    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /is-fullwidth-code-point/3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /is-glob/4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+    dev: true
+
+  /is-number/7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
+  /locate-path/3.0.0:
+    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-locate: 3.0.0
+      path-exists: 3.0.0
+    dev: true
+
+  /lodash.debounce/4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+    dev: true
+
+  /lodash.throttle/4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+    dev: true
+
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: true
+
+  /media-typer/0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /merge-descriptors/1.0.1:
+    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+    dev: true
+
+  /methods/1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-db/1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /mime-types/2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: true
+
+  /mime/1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: true
+
+  /ms/2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: true
+
+  /ms/2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: true
+
+  /negotiator/0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /normalize-path/3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /object-inspect/1.12.3:
+    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
+    dev: true
+
+  /on-finished/2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: true
+
+  /p-limit/2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-try: 2.2.0
+    dev: true
+
+  /p-locate/3.0.0:
+    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-limit: 2.3.0
+    dev: true
+
+  /p-try/2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /parseurl/1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /path-exists/3.0.0:
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /path-to-regexp/0.1.7:
+    resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+    dev: true
+
+  /picomatch/2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: true
+
+  /prettier/2.8.3:
+    resolution: {integrity: sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
+  /proxy-addr/2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    dev: true
+
+  /qs/6.11.0:
+    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: true
+
+  /range-parser/1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+    dev: true
+
+  /raw-body/2.5.1:
+    resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+    dev: true
+
+  /readdirp/3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
+    dev: true
+
+  /require-directory/2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /require-main-filename/2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+    dev: true
+
+  /rxjs/7.8.0:
+    resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
+    dependencies:
+      tslib: 2.5.0
+    dev: true
+
+  /safe-buffer/5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
+  /safer-buffer/2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: true
+
+  /send/0.18.0:
+    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /serve-static/1.15.0:
+    resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /set-blocking/2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+    dev: true
+
+  /setprototypeof/1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    dev: true
+
+  /shell-quote/1.7.4:
+    resolution: {integrity: sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==}
+    dev: true
+
+  /side-channel/1.0.4:
+    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.0
+      object-inspect: 1.12.3
+    dev: true
+
+  /spawn-command/0.0.2-1:
+    resolution: {integrity: sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==}
+    dev: true
+
+  /statuses/2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /string-width/3.1.0:
+    resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==}
+    engines: {node: '>=6'}
+    dependencies:
+      emoji-regex: 7.0.3
+      is-fullwidth-code-point: 2.0.0
+      strip-ansi: 5.2.0
+    dev: true
+
+  /string-width/4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+    dev: true
+
+  /strip-ansi/5.2.0:
+    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
+    engines: {node: '>=6'}
+    dependencies:
+      ansi-regex: 4.1.1
+    dev: true
+
+  /strip-ansi/6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-regex: 5.0.1
+    dev: true
+
+  /supports-color/7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
+  /supports-color/8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
+  /to-regex-range/5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
+    dev: true
+
+  /toidentifier/1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+    dev: true
+
+  /tree-kill/1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+    dev: true
+
+  /tslib/2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+    dev: true
+
+  /type-is/1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+    dev: true
+
+  /unpipe/1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /utils-merge/1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+    dev: true
+
+  /vary/1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+    dev: true
+
+  /which-module/2.0.0:
+    resolution: {integrity: sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==}
+    dev: true
+
+  /wrap-ansi/5.1.0:
+    resolution: {integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==}
+    engines: {node: '>=6'}
+    dependencies:
+      ansi-styles: 3.2.1
+      string-width: 3.1.0
+      strip-ansi: 5.2.0
+    dev: true
+
+  /wrap-ansi/7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
+
+  /y18n/4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+    dev: true
+
+  /y18n/5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+    dev: true
+
+  /yargs-parser/13.1.2:
+    resolution: {integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==}
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+    dev: true
+
+  /yargs-parser/21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /yargs/13.3.2:
+    resolution: {integrity: sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==}
+    dependencies:
+      cliui: 5.0.0
+      find-up: 3.0.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 3.1.0
+      which-module: 2.0.0
+      y18n: 4.0.3
+      yargs-parser: 13.1.2
+    dev: true
+
+  /yargs/17.6.2:
+    resolution: {integrity: sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+    dev: true

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const app = express();
 const port = 3000;
 
 app.get('/', (req, res) => {
-  res.send(fs.readFileSync('./dist/build.js').toString('utf-8'));
+  res.send(fs.readFileSync('./dist/build.user.js').toString());
 });
 
 app.listen(port, () => {

--- a/src/header.js
+++ b/src/header.js
@@ -4,10 +4,11 @@
 // @namespace https://github.com/SkyCloudDev
 // @author SkyCloudDev
 // @author x111000111
+// @author backwards
 // @description Downloads images and videos from posts
-// @version 2.2.6
-// @updateURL https://github.com/SkyCloudDev/ForumPostDownloader/raw/main/dist/build.js
-// @downloadURL https://github.com/SkyCloudDev/ForumPostDownloader/raw/main/dist/build.js
+// @version 2.3.3
+// @updateURL https://github.com/SkyCloudDev/ForumPostDownloader/raw/main/dist/build.user.js
+// @downloadURL https://github.com/SkyCloudDev/ForumPostDownloader/raw/main/dist/build.user.js
 // @icon https://simp4.jpg.church/simpcityIcon192.png
 // @license WTFPL; http://www.wtfpl.net/txt/copying/
 // @match https://simpcity.su/threads/*
@@ -20,16 +21,21 @@
 // @connect anonfiles.com
 // @connect box.com
 // @connect boxcloud.com
+// @connect kemono.party
 // @connect github.com
-// @connect bunkr.is
+// @connect bunkr.ru
+// @connect bunkr.la
 // @connect cyberdrop.me
 // @connect cyberdrop.cc
 // @connect cyberdrop.nl
 // @connect cyberdrop.to
-// @connect cyberfile.is
+// @connect cyberfile.su
 // @connect saint.to
 // @connect sendvid.com
-// @connect i.redd.it
+// @connect redd.it
+// @connect dailystar.co.uk
+// @connect pinuderest.com
+// @connect onlyfans.com
 // @connect i.ibb.co
 // @connect ibb.co
 // @connect imagebam.com
@@ -38,7 +44,9 @@
 // @connect imgbox.com
 // @connect pixhost.to
 // @connect pixl.is
+// @connect pixl.li
 // @connect pornhub.com
+// @connect postimg.cc
 // @connect img.kiwi
 // @connect instagram.com
 // @connect cdninstagram.com

--- a/src/header.js
+++ b/src/header.js
@@ -6,7 +6,7 @@
 // @author x111000111
 // @author backwards
 // @description Downloads images and videos from posts
-// @version 2.3.3
+// @version 2.3.5
 // @updateURL https://github.com/SkyCloudDev/ForumPostDownloader/raw/main/dist/build.user.js
 // @downloadURL https://github.com/SkyCloudDev/ForumPostDownloader/raw/main/dist/build.user.js
 // @icon https://simp4.jpg.church/simpcityIcon192.png

--- a/src/includes/globals.js
+++ b/src/includes/globals.js
@@ -1,3 +1,4 @@
 const JSZip = window.JSZip;
 const tippy = window.tippy;
 const http = window.GM_xmlhttpRequest;
+window.isFF = typeof InstallTrigger !== 'undefined';

--- a/src/includes/parsers.js
+++ b/src/includes/parsers.js
@@ -28,9 +28,18 @@ const parsers = {
       // 2. CodeBlock headers
       // 3. Spoiler button text from each spoiler
       // 2. Icons from un-furled urls (url parser can sometimes match them).
-      ['.js-unfurl-figure', '.js-unfurl-favicon', '.bbCodeBlock-title', 'blockquote', '.button-text > span']
+      ['.js-unfurl-figure', '.js-unfurl-favicon', 'blockquote', '.button-text > span']
         .flatMap(i => [...messageContentClone.querySelectorAll(i)])
-        .forEach(i => i.remove());
+        .forEach(i => {
+          if (i.tagName === 'BLOCKQUOTE') {
+            // Only remove blockquotes that quote the other posts.
+            if (i.querySelector('.bbCodeBlock-title')) {
+              i.remove();
+            }
+          } else {
+            i.remove();
+          }
+        });
 
       // Remove thread links.
       [...messageContentClone.querySelectorAll('.contentRow-header > a[href^="https://simpcity.su/threads"]')]

--- a/src/includes/settings.js
+++ b/src/includes/settings.js
@@ -5,7 +5,7 @@ const settings = {
   },
   hosts: {
     goFile: {
-      token: 'VtpRGPhRzOBbRsfcsCTDFDTolpAODQ88',
+      token: 'KPQJgKlYsy8JPmbuxj3MC4e5PFEpdZYP',
     },
   },
   ui: {

--- a/src/main.js
+++ b/src/main.js
@@ -1477,19 +1477,21 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
       saveAs(blob, filename);
       setProcessing(false, postId);
     } else {
-      let url = URL.createObjectURL(blob);
-      GM_download({
-        url,
-        name: `${title}/#${postNumber}/generated.zip`,
-        onload: () => {
-          URL.revokeObjectURL(url);
-          blob = null;
-        },
-        onerror: response => {
-          console.log(`Error writing file ${fn} to disk. There may be more details below.`);
-          console.log(response);
-        },
-      });
+      if (postSettings.generateLog || postSettings.generateLinks) {
+        let url = URL.createObjectURL(blob);
+        GM_download({
+          url,
+          name: `${title}/#${postNumber}/generated.zip`,
+          onload: () => {
+            URL.revokeObjectURL(url);
+            blob = null;
+          },
+          onerror: response => {
+            console.log(`Error writing file ${fn} to disk. There may be more details below.`);
+            console.log(response);
+          },
+        });
+      }
     }
   } else {
     setProcessing(false, postId);

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,7 @@ let processing = [];
  *
  * For a completely custom pattern, put !! (two excl. characters) anywhere in it:
  *
- * [/!!https:\/\/cyberfile.is\/\w+(?=")/, /cyberfile.is\/folder\//]
+ * [/!!https:\/\/cyberfile.su\/\w+(?=")/, /cyberfile.su\/folder\//]
  *
  * @signature string The name and categories of the host, separated by a colon.
  * @matchers array The name and categories of the host, separated by a colon.
@@ -44,8 +44,17 @@ let processing = [];
 const hosts = [
   ['simpcity.su:Attachments', [/simpcity.su\/attachments/]],
   ['anonfiles.com:', [/anonfiles.com/]],
-  ['jpg.church:image', [/simp\d+.jpg.church\//, /jpg.church\/a\/[~an@-_.]+<no_qs>/]],
-  ['ibb.co:image', [/!!https?:\/\/(www.)?([a-z](\d+)?\.)?ibb.co\/([~an@_.-])+(?=")/, /ibb.co\/album\/[~an@_.-]+/]],
+  ['jpg.church:image', [/simp(\d+.)?jpg.church\/(?!(banner-c\.png|img\/))/, /jpg.church\/a\/[~an@-_.]+<no_qs>/]],
+  ['kemono.party:direct link', [/.{2,6}\.kemono.party\/data\//]],
+  ['postimg.cc:image', [/!!https?:\/\/(www.)?i\.?(postimg|pixxxels).cc\/(.{8})/]], //[/!!https?:\/\/(www.)?postimg.cc\/(.{8})/]],
+  [
+    'ibb.co:image',
+    [
+      /!!((?<=href="|data-src="))https?:\/\/(www.)?([a-z](\d+)?\.)?ibb\.co\/([a-zA-Z0-9_.-]){7}((?=")|\/)(([a-zA-Z0-9_.-])+(?="))?/,
+      /ibb.co\/album\/[~an@_.-]+/,
+    ],
+  ],
+  ['imagevenue.com:image', [/!!https?:\/\/(www.)?imagevenue\.com\/(.{8})/]],
   ['img.kiwi:image', [/img.kiwi\/image\//, /img.kiwi\/album\//]],
   ['imgbox.com:image', [/(thumbs|images)(\d+)?.imgbox.com\//, /imgbox.com\/g\//]],
   [
@@ -54,24 +63,31 @@ const hosts = [
       /!!https:(\/|\\\/){2}s9e.github.io(\/|\\\/)iframe(\/|\\\/)2(\/|\\\/)imgur.*?(?="|&quot;)|(?<=")https:\/\/(www.)?imgur.(com|io).*?(?=")/,
     ],
   ],
+  ['onlyfans.com:image', [/public.onlyfans.com\/files/]],
+  ['dailystar.co.uk:image', [/i(\d+)?-prod\.dailystar.co.uk\/.*?\.(jpg|jpeg|png)/]],
+  ['pinuderest.com:image', [/pinuderest.com\/wp-content\/.*?\.(jpg|jpeg|png)/]],
   ['imgur.com:image', [/\w+\.imgur.(com|io)/]],
   ['reddit.com:image', [/(\w+)?.redd.it/]],
   ['instagram.com:Media', [/!!https:(\/|\\\/){2}s9e.github.io(\/|\\\/)iframe(\/|\\\/)2(\/|\\\/)instagram.*?(?="|&quot;)/]],
   ['instagram.com:Profile', [/!!instagram.com\/[~an@_.-]+|((instagram|insta):(\s+)?)@?[a-zA-Z0-9_.-]+/]],
+  ['nitter:image', [/nitter\.(.{1,20})\/pic/]],
   ['twitter.com:image', [/([~an@.]+)?twimg.com\//]],
-  ['pixl.is:image', [/([a-z](\d+)\.)pixl.(is|to)\/((img|image)\/)?/, /pixl.(is|to)\/album\//]],
+  ['pixl.li:image', [/([a-z](\d+)?\.)pixl.(li|is)\/((img|image)\/)?/, /pixl.(li|is)\/album\//]],
   ['pixhost.to:image', [/t(\d+)?\.pixhost.to\//, /pixhost.to\/gallery\//]],
   ['imagebam.com:image', [/imagebam.com\/(view|gallery)/]],
   ['saint.to:video', [/(saint.to\/embed\/|([~an@]+\.)?saint.to\/videos)/]],
   ['redgifs.com:video', [/!!redgifs.com(\/|\\\/)ifr.*?(?="|&quot;)/]],
   ['gfycat.com:video', [/!!gfycat.com(\/|\\\/)ifr.*?(?="|&quot;)/]],
-  ['bunkr.is:', [/(stream|cdn(\d+)?|i(\d+)?).bunkr.is\/(v\/)?/, /bunkr.is\/a\//]],
+  [
+    'bunkr.ru:',
+    [/!!(?<=href=")https:\/\/(stream|cdn(\d+)?).*?(?=")|(?<=(href="|src="))https:\/\/i(\d+)?.bunkr.ru\/(v\/)?.*?(?=")/, /bunkr.ru\/a\//],
+  ],
   ['pixeldrain.com:', [/pixeldrain.com\/[lu]\//]],
   ['gofile.com:', [/gofile.io\/d/]],
   ['erome.com:', [/erome.com\/a\//]],
   ['box.com:', [/m\.box\.com\//]],
   ['yandex.ru:', [/(disk\.)?yandex\.[a-z]+/]],
-  ['cyberfile.is:', [/!!https:\/\/cyberfile.is\/\w+(?=")/, /cyberfile.is\/folder\//]],
+  ['cyberfile.su:', [/!!https:\/\/cyberfile.su\/\w+(?=")/, /cyberfile.su\/folder\//]],
   ['cyberdrop.me:', [/fs-\d+.cyberdrop.(me|to|cc|nl)\//, /cyberdrop.(me|to|cc|nl)\/a\//]],
   ['pornhub.com:video', [/([~an@]+\.)?pornhub.com\/view_video/]],
   ['noodlemagazine.com:video', [/(adult.)?noodlemagazine.com\/watch\//]],
@@ -84,6 +100,26 @@ const hosts = [
  * @type {((RegExp[]|(function(*): *))[]|(RegExp[]|(function(*, *): Promise<{dom: *, source: *, folderName: *, resolved}>))[]|(RegExp[]|(function(*, *): Promise<string>))[]|(RegExp[]|(function(*, *): Promise<{dom: *, source: *, folderName: *, resolved}>))[]|(RegExp[]|(function(*): *))[])[]}
  */
 const resolvers = [
+  [
+    [/https?:\/\/nitter\.(.{1,20})\/pic\/(orig\/)?media%2F(.{1,15})/i],
+    url => url.replace(/https?:\/\/nitter\.(.{1,20})\/pic\/(orig\/)?media%2F(.{1,15})/i, 'https://pbs.twimg.com/media/$3'),
+  ],
+  [
+    [/imagevenue.com/],
+    async (url, http) => {
+      const { dom } = await http.get(url);
+      return dom.querySelector('.col-md-12 > a > img').getAttribute('src');
+    },
+  ],
+  [
+    [/(postimg|pixxxels).cc/],
+    async (url, http) => {
+      url = url.replace(/https?:\/\/(www.)?i\.?(postimg|pixxxels).cc\/(.{8})(.*)/, 'https://postimg.cc/$3');
+      const { dom } = await http.get(url);
+      return dom.querySelector('.controls > nobr > a').getAttribute('href');
+    },
+  ],
+  [[/kemono.party\/data/], url => url],
   [[/jpg.church\//i, /:!jpg.church\/a\//i], url => url.replace('.th.', '.').replace('.md.', '.')],
   [
     [/jpg.church\/a\//i],
@@ -118,29 +154,71 @@ const resolvers = [
     },
   ],
   [
-    [/([a-z](\d+)?\.)?ibb.co\/[a-zA-Z0-9-_.]+/, /:!([a-z](\d+)?\.)?ibb.co\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+/],
+    [/([a-z](\d+)?\.)?ibb.co\/[a-zA-Z0-9-_.]+/, /:!([a-z](\d+)?\.)?ibb.co\/album\/[a-zA-Z0-9_.-]+/],
     async (url, http) => {
       const { dom } = await http.get(url);
-      return dom.querySelector('.image-viewer-container > img').getAttribute('src');
+      return dom.querySelector('.header-content-right > a').getAttribute('href');
     },
   ],
   [
     [/([a-z](\d+)?\.)?ibb.co\/album\/[a-zA-Z0-9_.-]+/],
     async (url, http) => {
+      const albumId = url.replace(/\?.*/, '').split('/').reverse()[0];
       const { source, dom } = await http.get(url);
+      const imageCount = Number(dom.querySelector('span[data-text="image-count"]').innerText);
+      const pageCount = Math.ceil(imageCount / 32);
+      const authToken = h.re.match(/(?<=auth_token=").*?(?=")/i, source);
+
+      const fetchPageData = async (albumId, page, seekEnd, authToken) => {
+        const seek = seekEnd || '';
+        const data = `action=list&list=images&sort=date_desc&page=${page}&from=album&albumid=${albumId}&params_hidden%5Blist%5D=images&params_hidden%5Bfrom%5D=album&params_hidden%5Balbumid%5D=${albumId}&auth_token=${authToken}&seek=${seek}&items_per_page=32`;
+        const { source: response } = await http.post(
+          'https://ibb.co/json',
+          data,
+          {},
+          {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+        );
+
+        try {
+          const parsed = JSON.parse(response);
+
+          if (parsed && parsed.status_code && parsed.status_code === 200) {
+            const html = parsed.html.replace('"', '"');
+            return {
+              urls: h.re.matchAll(/(?<=data-object=').*?(?=')/gi, html).map(o => JSON.parse(decodeURIComponent(o)).url),
+              parsed,
+            };
+          }
+
+          return { urls: [], parsed };
+        } catch (e) {
+          return { urls: [], parsed };
+        }
+      };
+
+      const resolved = [];
+
+      let seekEnd = '';
+
+      for (let i = 1; i <= pageCount; i++) {
+        const data = await fetchPageData(albumId, i, seekEnd, authToken);
+        seekEnd = data.parsed.seekEnd;
+        resolved.push(...data.urls);
+      }
+
       return {
         dom,
         source,
         folderName: dom.querySelector('meta[property="og:title"]').content.trim(),
-        resolved: [...dom.querySelectorAll('.image-container > img')]
-          .map(img => img.getAttribute('src'))
-          .map(url => url.replace('.th.', '.').replace('.md.', '.')),
+        resolved,
       };
     },
   ],
-  [[/([a-z](\d+)\.)pixl.(is|to)\/((img|image)\/)?/, /:!pixl.(is|to)\/album\//], url => url.replace('.th.', '.').replace('.md.', '.')],
+  [[/([a-z](\d+)?\.)pixl.(li|is)\/((img|image)\/)?/, /:!pixl.(li|is)\/album\//], url => url.replace('.th.', '.').replace('.md.', '.')],
   [
-    [/pixl.(is|to)\/album\//],
+    [/pixl.(li|is)\/album\//],
     async (url, http) => {
       const { source, dom } = await http.get(url);
 
@@ -193,7 +271,7 @@ const resolvers = [
     },
   ],
   [
-    [/(stream|cdn(\d+)?|i(\d+)?).bunkr.is\/(v\/)?/, /:!bunkr.is\/a\//],
+    [/(stream|cdn(\d+)?|i(\d+)?).bunkr.ru\/(v\/)?/i, /:!bunkr.ru\/a\//],
     async (url, http) => {
       url = /(\.zip|\.pdf)/i.test(url) ? url.replace(/cdn\d+/, 'files') : url;
 
@@ -219,8 +297,8 @@ const resolvers = [
           return `${__NEXT_DATA__.props.pageProps.file.mediafiles}/${__NEXT_DATA__.props.pageProps.file.name}`;
         }
 
-        const filename = h.basename(url).replace('&amp;', '&');
-        const apiUrl = `https://stream.bunkr.is/_next/data/${buildId}/v/${filename}.json`;
+        const filename = h.basename(url).replace(/&amp;/g, '&');
+        const apiUrl = `https://stream.bunkr.ru/_next/data/${buildId}/v/${filename}.json`;
 
         const { source: apiSource } = await http.get(apiUrl);
 
@@ -237,7 +315,7 @@ const resolvers = [
     },
   ],
   [
-    [/bunkr.is\/a\//],
+    [/bunkr.ru\/a\//],
     async (url, http) => {
       const { source, dom } = await http.get(url);
 
@@ -475,12 +553,12 @@ const resolvers = [
     },
   ],
   [
-    [/cyberfile.is\//, /:!cyberfile.is\/folder\//],
+    [/cyberfile.su\//, /:!cyberfile.su\/folder\//],
     async (url, http) => {
       const { source } = await http.get(url);
       const u = h.re.matchAll(/(?<=showFileInformation\()\d+(?=\))/gis, source)[0];
       const { source: response } = await http.post(
-        'https://cyberfile.is/account/ajax/file_details',
+        'https://cyberfile.su/account/ajax/file_details',
         `u=${u}`,
         {},
         {
@@ -491,7 +569,7 @@ const resolvers = [
     },
   ],
   [
-    [/cyberfile.is\/folder\//],
+    [/cyberfile.su\/folder\//],
     async (url, http) => {
       const { source, dom } = await http.get(url);
 
@@ -500,7 +578,7 @@ const resolvers = [
       const nodeId = h.re.matchAll(/(?<='folder',\s').*?(?=')/gis, script);
 
       const { source: response } = await http.post(
-        'https://cyberfile.is/account/ajax/load_files',
+        'https://cyberfile.su/account/ajax/load_files',
         `pageType=folder&nodeId=${nodeId}`,
         {},
         {
@@ -523,7 +601,7 @@ const resolvers = [
           const { source } = await http.get(fileUrl);
           const u = h.re.matchAll(/(?<=showFileInformation\()\d+(?=\))/gis, source)[0];
           const { source: response } = await http.post(
-            'https://cyberfile.is/account/ajax/file_details',
+            'https://cyberfile.su/account/ajax/file_details',
             `u=${u}`,
             {},
             {
@@ -543,6 +621,9 @@ const resolvers = [
     },
   ],
   [[/([~an@]+\.)?saint.to\/videos/], async url => url],
+  [[/public.onlyfans.com\/files/], async url => url],
+  [[/dailystar.co.uk\//], async url => url],
+  [[/pinuderest.com\//], async url => url],
   [
     [/saint.to\/embed/],
     async (url, http) => {
@@ -553,9 +634,20 @@ const resolvers = [
   [
     [/redgifs.com(\/|\\\/)ifr/],
     async (url, http) => {
-      url = `https://redgifs.com/watch/${url.split('/').reverse()[0]}`;
-      const { dom } = await http.get(url);
-      return dom.querySelector('meta[property="og:video"]')?.content.replace('&amp;').trim();
+      const id = url.split('/').reverse()[0];
+      url = `https://api.redgifs.com/v2/gifs/${id}`;
+      const token = GM_getValue('redgifs_token', null);
+      const { source } = await http.get(url, {}, { Authorization: `Bearer ${token}` });
+      if (h.contains('urls', source)) {
+        const urls = JSON.parse(source).gif.urls;
+        if (urls.hd) {
+          return urls.hd;
+        }
+
+        return urls.sd;
+      }
+
+      return null;
     },
   ],
   [[/fs-\d+.cyberdrop.(me|to|cc|nl)\//, /:!cyberdrop.(me|to|cc|nl)\/a\//], url => url.replace(/(fs|img)-\d+/i, 'fs-01')],
@@ -700,7 +792,7 @@ const resolvers = [
   [
     [/gfycat.com(\/|\\\/)/],
     async (url, http) => {
-      url = `https://gfycat.com/${url.replace('&amp;', '&').split('/').reverse()[0].replace(/\?.*/is, '')}?hd=1`;
+      url = `https://gfycat.com/${url.replace(/&amp;/g, '&').split('/').reverse()[0].replace(/\?.*/is, '')}?hd=1`;
       const { dom } = await http.get(url);
       return [...dom.querySelectorAll('source')].map(el => el.getAttribute('src')).filter(src => src && h.contains('giant.gfycat', src))[0];
     },
@@ -779,7 +871,10 @@ const resolvers = [
     },
   ],
   [[/\w+\.imgur.(com|io)/], url => url],
-  [[/twimg.com\//], url => url.replace(':large', '').replace('&amp;', '&')],
+  [
+    [/twimg.com\//],
+    url => url.replace(/https?:\/\/pbs.twimg\.com\/media\/(.{1,15})(\?format=)?(.*)&amp;name=(.*)/, 'https://pbs.twimg.com/media/$1.$3'),
+  ],
   [
     [/(disk\.)?yandex\.[a-z]+/],
     async (url, http) => {
@@ -926,7 +1021,7 @@ const resolvers = [
       }
     },
   ],
-  [[/(\w+)?.redd.it/], url => url],
+  [[/(\w+)?.redd.it/], url => url.replace(/&amp;/g, '&')],
 ];
 
 const setProcessing = (isProcessing, postId) => {
@@ -939,7 +1034,7 @@ const setProcessing = (isProcessing, postId) => {
 };
 
 const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, getSettingsCB, statusUI, callbacks = {}) => {
-  const { postId, postNumber, pageNumber } = parsedPost;
+  const { postId, postNumber } = parsedPost;
 
   const postSettings = getSettingsCB();
 
@@ -1115,17 +1210,49 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
     }
   }
 
-  if (!postSettings.skipDownload) {
-    for (const { url, host, folderName } of resolved.filter(r => r.url)) {
-      h.ui.setElProps(statusLabel, { fontWeight: 'normal' });
-      const ellipsedUrl = h.limit(url, 80);
+  const isFF = window.isFF;
 
-      log.post.info(postId, `::Downloading::: ${url}`, postNumber);
-      // noinspection ES6MissingAwait
-      h.http.get(
-        url,
-        {
-          onStateChange: response => {
+  if (!postSettings.skipDownload) {
+    const resources = resolved.filter(r => r.url);
+    totalDownloadable = resources.length;
+
+    const batchLength = 2;
+
+    let currentBatch = 0;
+
+    const batches = [];
+
+    for (let i = 0; i < totalDownloadable; i += batchLength) {
+      batches.push(resources.slice(i, i + batchLength));
+    }
+
+    const getNextBatch = () => {
+      const batch = currentBatch < batches.length ? batches[currentBatch] : [];
+      currentBatch++;
+      return batch;
+    };
+
+    const requestProgress = [];
+
+    const requests = [];
+
+    let completedBatchedDownloads = 0;
+
+    let batch = getNextBatch();
+
+    while (batch.length) {
+      for (const { url, host, original, folderName } of batch) {
+        h.ui.setElProps(statusLabel, { fontWeight: 'normal' });
+        const ellipsedUrl = h.limit(url, 80);
+
+        log.post.info(postId, `::Downloading::: ${url}`, postNumber);
+        const request = GM_xmlhttpRequest({
+          url,
+          headers: {
+            Referer: original,
+          },
+          responseType: 'blob',
+          onreadystatechange: response => {
             if (response.readyState === 2) {
               let matches = h.re.matchAll(/(?<=attachment;filename=").*?(?=")/gis, response.responseHeaders);
               if (matches.length && !filenames.find(f => f.url === url)) {
@@ -1137,8 +1264,7 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
               }
             }
           },
-          onProgress: response => {
-            callbacks && callbacks.onFileDownloadProgress && callbacks.onFileDownloadProgress({ response, url, totalCompleted: completed });
+          onprogress: response => {
             h.ui.setElProps(statusLabel, {
               color: '#469cf3',
             });
@@ -1157,10 +1283,16 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
                 width: `${(response.loaded / response.total) * 100}%`,
               });
             }
+            const p = requestProgress.find(r => r.url === url);
+            p.new = response.loaded;
           },
-          onLoad: response => {
+          onload: response => {
             completed++;
-            callbacks && callbacks.onFileDownloaded && callbacks.onFileDownloaded({ response, url, totalCompleted: completed });
+            completedBatchedDownloads++;
+
+            const p = requestProgress.find(r => r.url === url);
+            clearInterval(p.intervalId);
+
             h.ui.setText(statusLabel, `${completed} / ${totalDownloadable} 🢒 ${ellipsedUrl}`);
             h.ui.setElProps(statusLabel, { color: '#2d9053' });
             h.ui.setElProps(totalPB, {
@@ -1170,7 +1302,22 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
             // TODO: Extract to method.
             const filename = filenames.find(f => f.url === url);
 
-            let basename = filename ? filename.name : h.basename(url).replace(/\?.*/, '').replace(/#.*/, '');
+            let basename;
+
+            if (url.includes('https://pixeldrain.com/')) {
+              basename = response.responseHeaders.match(/^content-disposition.+(?:filename=)(.+)$/im)[1].replace(/\"/g, '');
+            } else if (url.includes('https://simpcity.su/attachments/')) {
+              basename = filename ? filename.name : h.basename(url).replace(/(.*)-(.{3,4})\.\d*$/i, '$1.$2');
+            } else if (url.includes('kemono.party')) {
+              basename = filename
+                ? filename.name
+                : h
+                    .basename(url)
+                    .replace(/(.*)\?f=(.*)/, '$2')
+                    .replace('%20', ' ');
+            } else {
+              basename = filename ? filename.name : h.basename(url).replace(/\?.*/, '').replace(/#.*/, '');
+            }
 
             let ext = h.ext(basename);
 
@@ -1201,10 +1348,6 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
               filenames.push({ url, name: basename, original });
             }
 
-            if (totalDownloadable === 1 && customFilename) {
-              basename = customFilename;
-            }
-
             const folder = folderName || '';
 
             let fn = basename;
@@ -1222,32 +1365,86 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
               log.post.info(postId, `::Saving as::: ${basename}`, postNumber);
             }
 
-            zip.file(fn, response.response);
-          },
-          onError: () => {
-            completed++;
-          },
-        },
-        {},
-        'blob',
-      );
-    }
+            let blob = URL.createObjectURL(response.response);
 
-    while (completed < totalDownloadable) {
-      await h.delayedResolve(1000);
+            let title = threadTitle.replace(/[\\\/]/g, settings.naming.invalidCharSubstitute);
+
+            // https://stackoverflow.com/a/53681022
+            fn = fn.replace(/[\x00-\x08\x0E-\x1F\x7F-\uFFFF]/g, '');
+
+            if (!isFF) {
+              fn = `#${postNumber}/${fn}`;
+            }
+
+            const saveAs = `${title}/${fn}`;
+
+            if (!isFF) {
+              GM_download({
+                url: blob,
+                name: saveAs,
+                onload: () => {
+                  URL.revokeObjectURL(blob);
+                  blob = null;
+                },
+                onerror: response => {
+                  console.log(`Error writing file ${fn} to disk. There may be more details below.`);
+                  console.log(response);
+                },
+              });
+            } else {
+              zip.file(fn, response.response);
+            }
+          },
+          onerror: () => {
+            completed++;
+            completedBatchedDownloads++;
+          },
+        });
+
+        requests.push({ url, request });
+
+        const intervalId = setInterval(() => {
+          const p = requestProgress.find(r => r.url === url);
+          if (p.old === p.new) {
+            const r = requests.find(r => r.url === url);
+            r.request.abort();
+            clearInterval(p.intervalId);
+            completed++;
+            completedBatchedDownloads++;
+          } else {
+            p.old = p.new;
+          }
+        }, 30000);
+
+        requestProgress.push({ url, intervalId, old: 0, new: 0 });
+      }
+
+      while (completedBatchedDownloads < batch.length) {
+        await h.delayedResolve(1000);
+      }
+
+      if (completedBatchedDownloads >= batch.length) {
+        completedBatchedDownloads = 0;
+      }
+
+      batch = getNextBatch();
     }
   } else {
     log.post.info(postId, '::Skipping download::', postNumber);
   }
 
+  h.hide(statusLabel);
+  h.hide(filePB);
+  h.hide(totalPB);
+  window.logs = window.logs.filter(l => l.postId !== postId);
+
+  if (!isFF) {
+    setProcessing(false, postId);
+  }
+
   if (totalDownloadable > 0) {
     let title = threadTitle.replace(/[\\\/]/g, settings.naming.invalidCharSubstitute);
-
-    // https://stackoverflow.com/a/9851769
-    // Will be deprecated in the future according to FF.
-    const isFF = typeof InstallTrigger !== 'undefined';
-
-    const filename = customFilename || (isFF ? `${title} #${postNumber}.zip` : `#${postNumber}.zip`);
+    const filename = customFilename || `${title} #${postNumber}.zip`;
 
     log.separator(postId);
     log.post.info(postId, `::Preparing zip::`, postNumber);
@@ -1255,7 +1452,7 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
     if (postSettings.generateLog) {
       log.post.info(postId, `::Generating log file::`, postNumber);
       zip.file(
-        'generated/log.txt',
+        isFF ? 'generated/log.txt' : 'log.txt',
         logs
           .filter(l => l.postId === postId)
           .map(l => l.message)
@@ -1266,7 +1463,7 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
     if (postSettings.generateLinks) {
       log.post.info(postId, `::Generating links::`, postNumber);
       zip.file(
-        'generated/links.txt',
+        isFF ? 'generated/links.txt' : 'links.txt',
         resolved
           .filter(r => r.url)
           .map(r => r.url)
@@ -1275,38 +1472,32 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
     }
 
     let blob = await zip.generateAsync({ type: 'blob' });
-    const url = URL.createObjectURL(blob);
 
     if (isFF) {
-      // Firefox won't save in a custom dir.
       saveAs(blob, filename);
+      setProcessing(false, postId);
     } else {
+      let url = URL.createObjectURL(blob);
       GM_download({
         url,
-        name: `${title}/${filename}`,
+        name: `${title}/#${postNumber}/generated.zip`,
         onload: () => {
           URL.revokeObjectURL(url);
           blob = null;
         },
         onerror: response => {
-          console.log('Error downloading the requested post. There may be more details below.');
+          console.log(`Error writing file ${fn} to disk. There may be more details below.`);
           console.log(response);
         },
       });
     }
-
-    setProcessing(false, postId);
   } else {
     setProcessing(false, postId);
   }
 
-  h.hide(statusLabel);
-  h.hide(filePB);
-  h.hide(totalPB);
-
   if (totalDownloadable > 0) {
     // For logging in console since post logs are already written.
-    if (postSettings.skipDownload) {
+    if (!postSettings.skipDownload) {
       log.post.info(postId, `::Download completed::`, postNumber);
     } else {
       log.post.info(postId, `::Links generation completed::`, postNumber);
@@ -1314,9 +1505,6 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
 
     callbacks && callbacks.onComplete && callbacks.onComplete(totalDownloadable, completed);
   }
-
-  // TODO: Fix this filth.
-  window.logs = window.logs.filter(l => l.postId !== postId);
 };
 
 /**
@@ -1386,7 +1574,7 @@ const registerPostReaction = postFooter => {
   if (!hasReaction) {
     const reactionAnchor = postFooter.querySelector('.reaction--imageHidden');
     if (reactionAnchor) {
-      reactionAnchor.setAttribute('href', reactionAnchor.getAttribute('href').replace('_id=1', '_id=2'));
+      reactionAnchor.setAttribute('href', reactionAnchor.getAttribute('href').replace('_id=1', '_id=33'));
       reactionAnchor.click();
     }
   }
@@ -1403,6 +1591,7 @@ const selectedPosts = [];
       return message;
     }
   });
+
   document.addEventListener('DOMContentLoaded', async () => {
     const goFileTokenFetchFailedErr = 'Failed to create GoFile token. GoFile albums may not work. Refresh the browser to retry.';
 
@@ -1428,6 +1617,17 @@ const selectedPosts = [];
       }
     }
 
+    try {
+      const { source } = await h.http.get('https://api.redgifs.com/v2/auth/temporary');
+      if (h.contains('token', source)) {
+        const token = JSON.parse(source).token;
+        GM_setValue('redgifs_token', token);
+      }
+    } catch (e) {
+      console.error('Error getting temporary redgifs auth token:');
+      console.error(e);
+    }
+
     init.injectCustomStyles();
 
     h.elements('.message-attribution-opposite').forEach(post => {
@@ -1435,7 +1635,7 @@ const selectedPosts = [];
         flatten: false,
         generateLinks: false,
         generateLog: false,
-        skipDuplicates: true,
+        skipDuplicates: false,
         skipDownload: false,
         output: [],
       };
@@ -1461,8 +1661,9 @@ const selectedPosts = [];
 
       // Create and attach the download button to post.
       const { btn: btnDownloadPost } = ui.buttons.addDownloadPostButton(post);
+      const totalResources = parsedHosts.reduce((acc, host) => acc + host.resources.length, 0);
       const checkedLength = getTotalDownloadableResourcesForPostCB(parsedHosts);
-      btnDownloadPost.innerHTML = `🡳 Download (${checkedLength})`;
+      btnDownloadPost.innerHTML = `🡳 Download (${checkedLength}/${totalResources})`;
 
       // Create download status / progress elements.
       const { el: statusText } = ui.labels.status.createStatusLabel();

--- a/src/main.js
+++ b/src/main.js
@@ -1436,7 +1436,6 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
   h.hide(statusLabel);
   h.hide(filePB);
   h.hide(totalPB);
-  window.logs = window.logs.filter(l => l.postId !== postId);
 
   if (!isFF) {
     setProcessing(false, postId);
@@ -1507,6 +1506,8 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
 
     callbacks && callbacks.onComplete && callbacks.onComplete(totalDownloadable, completed);
   }
+
+  window.logs = window.logs.filter(l => l.postId !== postId);
 };
 
 /**


### PR DESCRIPTION
- Download resources in batches (default batch size: 2).
- For browsers other than Firefox, do not generate a zip and write to disk as soon as the file is downloaded.
- Remove custom filename for browsers other than Firefox.
- Only remove blockquotes from messages when it references another post.
- Fix duplicate jpg.church image detection for some posts.
- Fix duplicate bunkr.ru image/video detection for some posts.
- Add ability to download direct images from pinuderest.com
- Add ability to download direct images from dailystar.co.uk
- Add ability to download public images from onlyfans.com
- Sync project with /dist/build.user.js
- Fix formatting