### PR TITLE
Fix Filester (broken v1 API), GoFile (site redesign + single-file links), add Goonbox Cloudflare bridge (3.22)

### DIFF
--- a/dist/build.user.js
+++ b/dist/build.user.js
@@ -4,7 +4,7 @@
 // @namespace https://github.com/SkyCloudDev
 // @author SkyCloudDev
 // @description Downloads images and videos from posts
-// @version 3.21
+// @version 3.22
 // @updateURL https://github.com/SkyCloudDev/ForumPostDownloader/raw/main/dist/build.user.js
 // @downloadURL https://github.com/SkyCloudDev/ForumPostDownloader/raw/main/dist/build.user.js
 // @icon https://simp4.cuckcapital.cr/simpcityIcon192.png
@@ -16,6 +16,8 @@
 // @match https://simpcity.rs/threads/*
 // @match https://simpcity.ax/threads/*
 // @match https://gofile.io/*
+// @match https://goonbox.cr/*
+// @match https://*.goonbox.cr/*
 // @require https://unpkg.com/@popperjs/core@2
 // @require https://unpkg.com/tippy.js@6
 // @require https://unpkg.com/file-saver@2.0.4/dist/FileSaver.min.js
@@ -125,6 +127,7 @@
 // @grant GM_download
 // @grant GM_setValue
 // @grant GM_getValue
+// @grant GM_addValueChangeListener
 // @grant GM_log
 // @grant GM_openInTab
 // @grant GM_cookie
@@ -155,6 +158,24 @@ const tippy = window.tippy;
 const http = window.GM_xmlhttpRequest;
 window.isFF = typeof InstallTrigger !== 'undefined';
 window.logs = [];
+
+// Script version, logged once per post run so a pasted log identifies its own build. Test reports
+// were previously ambiguous about which version produced them, which is a bad way to lose an
+// afternoon. GM_info needs no @grant in either manager, but read it defensively through the same
+// fallback shape used elsewhere -- a missing value here must never break a download.
+const xfpdVersion = (() => {
+    try {
+        const info =
+            (typeof GM_info !== 'undefined' && GM_info) ||
+            (typeof window !== 'undefined' && window.GM_info) ||
+            (typeof GM === 'object' && GM && GM.info) ||
+            null;
+        const v = info && info.script && info.script.version;
+        return v ? String(v) : 'unknown';
+    } catch (e) {
+        return 'unknown';
+    }
+})();
 
 const log = {
     /**
@@ -422,14 +443,140 @@ function filesterTokenFromVUrl(u) {
     } catch (e) { return ''; }
 }
 
-function filesterBuildCandidates(token) {
+// Stream hosts, in probe order. Filester migrated its CDN to fscN.cdn.cr (2026-07), so those go
+// first. The legacy cacheN.filester.me set is kept as a fallback tail — Filester had maintenance
+// recently and may restore them.
+//
+// Ordering matters more than membership here. As of 2026-07-29 cache2/3/4/5/7/8 are NXDOMAIN, which
+// costs nothing (instant failure), but cache1 and cache6 still resolve and then **accept the
+// connection and never answer** — ~78s each against Chrome's socket timeout. Two of those in the old
+// order (apiBase, cache6, cache1, ...) is exactly the ~157s per link that was observed.
+const FILESTER_STREAM_HOSTS = [
+    'https://fsc1.cdn.cr',
+    'https://fsc2.cdn.cr',
+    'https://fsc3.cdn.cr',
+    // Legacy tail, cheapest-first: these six are NXDOMAIN today, so they fail instantly and cost
+    // nothing if Filester has not restored them.
+    'https://cache2.filester.me',
+    'https://cache3.filester.me',
+    'https://cache4.filester.me',
+    'https://cache5.filester.me',
+    'https://cache7.filester.me',
+    'https://cache8.filester.me',
+    // Last: these two resolve but black-hole the connection, so each costs a full probe timeout.
+    // Kept only so they start working again by themselves if Filester brings them back.
+    'https://cache6.filester.me',
+    'https://cache1.filester.me',
+];
+
+// Per-request deadline for a speculative probe, and a cap on the whole sweep. Both are load-bearing:
+// without them a single black-holing host stalls the entire resolution loop.
+const FILESTER_PROBE_TIMEOUT_MS = 8000;
+const FILESTER_PROBE_BUDGET_MS = 25000;
+// API/HTML steps are on the critical path (no fallback host to try), so they get a looser deadline.
+const FILESTER_API_TIMEOUT_MS = 20000;
+
+// `apiBase` first on Chrome: Tampermonkey downloads are more reliable started from the site origin,
+// since the redirects preserve a Filester referrer.
+function filesterStreamBases(apiBase) {
+    const base = String(apiBase || 'https://filester.me').replace(/\/$/, '');
+    const out = [];
+    if (!isFF) out.push(base);
+    for (const h of FILESTER_STREAM_HOSTS) out.push(h);
+    if (isFF) out.push(base);
+    return out.filter((v, i, a) => a.indexOf(v) === i);
+}
+
+function filesterBuildCandidates(token, apiBase) {
     const t = String(token || '').trim();
     if (!t) return [];
-    const order = [6, 1, 2, 3, 4, 5, 7, 8];
-    const out = [];
-    for (const n of order) out.push(`https://cache${n}.filester.me/v/${t}`);
-    out.push(`https://filester.me/v/${t}`);
-    return out;
+    return filesterStreamBases(apiBase).map(b => `${b}/v/${t}`);
+}
+
+// Filester v2 public API -- the only resolver that still works. The v1 /api/public/download
+// endpoint keeps answering 200 with a legacy-shaped payload whose /v/<token> URL now 404s on every
+// CDN host, so anything still calling it silently produces dead links.
+//   POST {apiBase}/v2/api/public/download  {file_slug}
+//     -> { server, file: "<uuid>.<ext>", token, name, expires_in }
+//   URL = `${server}/v2/${file}?token=${token}&download=true&n=${name}`
+// `server` is whichever host Filester picks (fsc1/fsc2/fsc3.cdn.cr today, and it does vary per
+// request) -- take it as given rather than validating it against a known-host list, which is what
+// broke a third-party build when fsc3 started appearing. There is no host ladder to walk here:
+// the token is only valid for the server that issued it, so `filesterBuildCandidates` must not be
+// used on a v2 URL.
+//
+// Shared by the /d/ link resolver and by the download-time resolver for album (/f/) slugs. The
+// latter used to carry its own v1 copy of this, which is why single links worked while albums
+// still fell back to fscN.cdn.cr/v/<token> and 404'd.
+//
+// Tokens are IP-bound and expire in ~30 min, so callers should resolve as late as possible.
+async function filesterResolveV2(http, apiBase, slug, progressCB) {
+    const base = String(apiBase || 'https://filester.me').replace(/\/$/, '');
+    const s = String(slug || '').trim();
+    if (!s) return null;
+
+    try {
+        if (typeof progressCB === 'function') progressCB('[Filester] Requesting download token (v2)...');
+
+        const res = await http.base(
+            'POST',
+            `${base}/v2/api/public/download`,
+            {},
+            {
+                Accept: 'application/json, text/plain, */*',
+                'Content-Type': 'application/json;charset=UTF-8',
+                Origin: base,
+                Referer: `${base}/d/${s}`,
+                __xfpd_withCredentials: true,
+                __xfpd_timeout: FILESTER_API_TIMEOUT_MS,
+            },
+            JSON.stringify({ file_slug: s }),
+            'text',
+        );
+
+        let j = null;
+        try { j = JSON.parse(String((res && res.source) || '')); } catch (e) {}
+
+        const server = String((j && j.server) || '').replace(/\/$/, '');
+        const file = String((j && j.file) || '');
+        const token = String((j && j.token) || '');
+        const name = String((j && j.name) || '');
+        if (!server || !file || !token) return null;
+
+        // Encode per path segment, not with encodeURI: encodeURI leaves `#` alone, which would
+        // truncate the URL at the fragment. `file` is "<uuid>.<ext>" today, so this normally
+        // changes nothing -- it just stops a stray character from silently killing the download.
+        const filePath = String(file).split('/').map(encodeURIComponent).join('/');
+        let streamUrl = `${server}/v2/${filePath}?token=${encodeURIComponent(token)}&download=true`;
+        if (name) streamUrl += `&n=${encodeURIComponent(name)}`;
+
+        // The response carries the real filename, so there is no extension guessing to do beyond
+        // the (rare) case of a nameless response.
+        const finalName = name || `Filester_${s}${(/\.[A-Za-z0-9]{1,8}$/.exec(file) || [''])[0]}`;
+        // The CDN wants a Filester referer; the /d/ page is the one the site itself uses.
+        const ref = `${base}/d/${s}`;
+
+        try { filesterSlugByUrl.set(String(streamUrl), String(s)); } catch (e) {}
+        try { filesterRefByUrl.set(String(streamUrl), String(ref)); } catch (e) {}
+        try {
+            filesterNameBySlug.set(String(s), String(finalName));
+            filesterNameByUrl.set(String(streamUrl), String(finalName));
+        } catch (e) {}
+
+        return { url: streamUrl, name: finalName, ref, token, server, file };
+    } catch (e) {}
+
+    return null;
+}
+
+// A resolved Filester stream URL lives on a CDN host we do not control the naming of, so recognise
+// it by the slug map we populate at resolution time rather than by hostname -- pattern-matching
+// fscN.cdn.cr would break again the next time Filester renames its CDN.
+function isFilesterUrl(u) {
+    const s = String(u || '');
+    if (/(?:^|\/\/)(?:[a-z0-9-]+\.)*filester\.(me|sh|si|gg)\/(?:d|v)\//i.test(s)) return true;
+    try { if (filesterSlugByUrl.has(s)) return true; } catch (e) {}
+    return false;
 }
 
 // Bunkr filename hints (from /v/ pages)
@@ -439,6 +586,480 @@ const bunkrNameByUrl = new Map();
 // API's original_url 404s (post-migration, some originals are missing but the .md. thumbnail --
 // also hosted on cuckcapital.cr -- still exists).
 const goonboxThumbByUrl = new Map();
+
+// --- Goonbox same-origin API bridge -------------------------------------------------------------
+// Goonbox's API sits behind Cloudflare and requires the first-party goonbox.cr cookies. On Firefox
+// a GM_xmlhttpRequest issued from the SimpCity tab is a third-party request and does not carry
+// them, so /api/images/* and /api/albums/* answer 403. No header we can set fixes that -- the
+// cookies are not ours to send.
+//
+// The workaround (from a contributor) is to keep one inactive goonbox.cr tab. This script also runs
+// there (see the @match), where it *is* same-origin and `fetch(..., {credentials:'include'})`
+// carries the real cookies. The two tabs talk over GM storage, which is shared per-script across
+// tabs.
+//
+// The direct GM_xmlhttpRequest stays the first attempt: it still works on Chrome/Tampermonkey and
+// costs a single request. The tab is only opened when that first attempt comes back 403, empty, or
+// unparseable, so nothing changes for users who were never affected.
+const GOONBOX_ORIGIN = 'https://goonbox.cr';
+
+const GBX_K_READY = 'xfpd_gbx_ready';
+const GBX_K_REQ = 'xfpd_gbx_req';
+const GBX_K_RES = 'xfpd_gbx_res';
+
+const GBX_POLL_MS = 150;
+const GBX_HEARTBEAT_MS = 1000;
+const GBX_READY_TIMEOUT_MS = 20000;
+const GBX_REQ_TIMEOUT_MS = 25000;
+// Close a few seconds after the *last* request, not after each one: a post usually resolves several
+// Goonbox links, and reopening a tab per link would be slow and conspicuous.
+const GBX_IDLE_CLOSE_MS = 5000;
+// Cloudflare may still be settling when the helper tab first runs, so a single same-origin attempt
+// is not enough to conclude anything.
+const GBX_FETCH_ATTEMPTS = 3;
+const GBX_FETCH_RETRY_MS = 800;
+
+// The helper tab is opened on a *real* Goonbox page (the image or album being resolved) with this
+// marker appended, rather than on the bare origin.
+//
+// Two reasons, both from contributor testing of b08. First, empirical: on Firefox + Tampermonkey a
+// tab opened at `https://goonbox.cr/` never ran this script at all -- no heartbeat ever arrived, so
+// every resolve ate the full 20s readiness timeout and then failed. Opening the actual content URL
+// works. The most likely mechanism is that the bare origin redirects somewhere the @match does not
+// cover (`www.`, most plausibly), so the script is never injected; hence the added wildcard @match
+// as well. Chrome + Tampermonkey and Firefox + Violentmonkey were unaffected, which is why b08
+// tested clean everywhere else.
+//
+// Second, the marker gates the worker: only a tab we opened serves the bridge. A user browsing
+// goonbox.cr normally no longer becomes an unwitting bridge, and `gbxBridgeAlive()` now reflects
+// only our own helper tab, which makes readiness mean one specific thing instead of two.
+const GBX_MARKER_KEY = 'xfpd_gbx';
+const GBX_MARKER_VAL = '1';
+
+// Only these two API shapes may cross the bridge. The helper tab builds the final URL itself as
+// GOONBOX_ORIGIN + path and never accepts a full URL, so an unexpected value in GM storage cannot
+// turn a cookie-bearing tab into a general-purpose authenticated proxy. Enforced on both sides.
+const GBX_ALLOWED_PATHS = [
+    /^\/api\/images\/[A-Za-z0-9_-]{1,64}$/,
+    /^\/api\/albums\/[A-Za-z0-9._~-]{1,128}\/images\?page=\d{1,4}$/,
+];
+
+function goonboxBridgePathAllowed(p) {
+    const s = String(p || '');
+    return GBX_ALLOWED_PATHS.some(rx => rx.test(s));
+}
+
+// --- cross-tab delivery ---------------------------------------------------------------------
+// GM storage reads are NOT reliably cross-tab. Tampermonkey keeps a per-tab in-memory cache, and
+// GM_getValue reads that cache -- so a tab polling for another tab's write can sit reading its own
+// stale copy indefinitely. That is exactly what stalled the bridge on Firefox + Tampermonkey
+// (b13): the helper tab heartbeated correctly and the script was confirmed running in it, while
+// the SimpCity tab polled its own cache, saw nothing, and timed out after two 20s waits. Chrome +
+// TM and Firefox + VM happen to propagate, which is why it worked there and hid the assumption.
+//
+// GM_addValueChangeListener is the documented mechanism for this: the callback is handed newValue
+// directly, so no cache is ever consulted. Polling is **kept alongside** it rather than replaced --
+// it demonstrably works on the configurations that already worked, and the two paths dedupe
+// naturally (by request id, and by taking whichever heartbeat is newer), so whichever arrives
+// first wins and neither can double-handle a request.
+const xfpdAddValueChangeListener =
+    (typeof GM_addValueChangeListener === 'function' ? GM_addValueChangeListener : null) ||
+    (typeof window.GM_addValueChangeListener === 'function' ? window.GM_addValueChangeListener.bind(window) : null);
+
+// Mirrors fed by the listener, consulted alongside the polled value.
+let gbxReadyMirror = 0;
+let gbxResMirror = '';
+let gbxListenersBound = false;
+
+function gbxBindListeners() {
+    if (gbxListenersBound || !xfpdAddValueChangeListener) return;
+    gbxListenersBound = true;
+    try {
+        xfpdAddValueChangeListener(GBX_K_READY, (name, oldV, newV) => {
+            // Last write wins: heartbeats are monotonic, and tab close writes 0 to clear.
+            gbxReadyMirror = Number(newV || 0) || 0;
+        });
+    } catch (e) {}
+    try {
+        xfpdAddValueChangeListener(GBX_K_RES, (name, oldV, newV) => {
+            gbxResMirror = String(newV || '');
+        });
+    } catch (e) {}
+}
+
+const gbxSleep = ms => new Promise(r => setTimeout(r, ms));
+
+function gbxGet(key, dflt = '') {
+    try { return GM_getValue(key, dflt); } catch (e) { return dflt; }
+}
+
+function gbxSet(key, val) {
+    try { GM_setValue(key, val); } catch (e) {}
+}
+
+// --- requester side (runs in the SimpCity tab) ---
+let gbxTabHandle = null;
+let gbxIdleTimer = null;
+let gbxChain = Promise.resolve();
+let gbxSeq = 0;
+// Circuit breaker. If the helper tab never announces itself -- almost always a Cloudflare
+// interstitial that needs a human -- every later link would otherwise pay the full readiness
+// timeout again, since the tab handle exists and so is never reopened. A five-page album would
+// stall for minutes to produce nothing. Back off instead, but not permanently: the user may well
+// go and clear the interstitial in the tab we just opened for them.
+let gbxUnavailableUntil = 0;
+let gbxInFlight = 0;
+const GBX_BREAKER_MS = 120000;
+
+// The helper tab heartbeats while it is alive, so a stale value from a previous session (browser
+// closed, tab killed) reads as dead rather than wedging the next run.
+function gbxBridgeAlive() {
+    // Whichever source is fresher. The polled read is authoritative where propagation works; the
+    // listener mirror is the only source that sees anything at all on Firefox + Tampermonkey.
+    const polled = Number(gbxGet(GBX_K_READY, 0) || 0) || 0;
+    const t = Math.max(polled, gbxReadyMirror);
+    return t > 0 && (Date.now() - t) < (GBX_HEARTBEAT_MS * 5);
+}
+
+function gbxCloseTab() {
+    try { if (gbxIdleTimer) clearTimeout(gbxIdleTimer); } catch (e) {}
+    gbxIdleTimer = null;
+    // window.close() from inside the tab is unreliable on Chrome; close via the GM_openInTab
+    // handle instead (xfpdCloseTabHandle also copes with implementations returning Promise<Tab>).
+    try { xfpdCloseTabHandle(gbxTabHandle); } catch (e) {}
+    gbxTabHandle = null;
+    gbxSet(GBX_K_READY, 0);
+    gbxSet(GBX_K_REQ, '');
+    gbxSet(GBX_K_RES, '');
+}
+
+// The idle timer must be cancelled when a request *starts*, not only re-armed when one finishes.
+// In b08 it was armed on settle only, so the 5s timer left by request N could fire in the middle of
+// request N+1 and close the tab out from under it -- the in-flight request then saw a dead bridge
+// and returned null. Back-to-back album pages usually finished inside the 5s window and hid it, but
+// any request slower than that (or one that had to wait out a tab reopen) hit it.
+function gbxCancelIdleTimer() {
+    try { if (gbxIdleTimer) clearTimeout(gbxIdleTimer); } catch (e) {}
+    gbxIdleTimer = null;
+}
+
+function gbxMaybeArmIdleTimer() {
+    gbxCancelIdleTimer();
+    // Only once nothing is outstanding. gbxInFlight is a counter rather than a boolean so this
+    // stays correct if the serialization above is ever relaxed.
+    if (gbxInFlight > 0) return;
+    gbxIdleTimer = setTimeout(() => { try { gbxCloseTab(); } catch (e) {} }, GBX_IDLE_CLOSE_MS);
+}
+
+// A real Goonbox URL plus the marker that tells the injected script to serve the bridge.
+function gbxHelperUrl(pageUrl) {
+    const base = String(pageUrl || '').trim();
+    try {
+        const u = new URL(base);
+        if (/(^|\.)goonbox\.cr$/i.test(u.hostname)) {
+            u.searchParams.set(GBX_MARKER_KEY, GBX_MARKER_VAL);
+            return u.href;
+        }
+    } catch (e) {}
+    // No usable content URL -- fall back to the origin. Known not to work on Firefox +
+    // Tampermonkey (see GBX_MARKER_KEY), but better than not trying.
+    return `${GOONBOX_ORIGIN}/?${GBX_MARKER_KEY}=${GBX_MARKER_VAL}`;
+}
+
+function gbxOpenTab(pageUrl) {
+    gbxSet(GBX_K_READY, 0);
+    try {
+        return GM_openInTab(gbxHelperUrl(pageUrl), { active: false, insert: true, setParent: true });
+    } catch (e) {
+        return null;
+    }
+}
+
+async function gbxAwaitReady() {
+    const deadline = Date.now() + GBX_READY_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+        if (gbxBridgeAlive()) return true;
+        await gbxSleep(GBX_POLL_MS);
+    }
+    return false;
+}
+
+async function gbxEnsureTab(pageUrl) {
+    // Must happen before the first gbxBridgeAlive() read, or the heartbeat that arrives while we
+    // are opening the tab has nowhere to land.
+    gbxBindListeners();
+
+    if (gbxBridgeAlive()) {
+        gbxUnavailableUntil = 0;
+        return true;
+    }
+    if (Date.now() < gbxUnavailableUntil) return false;
+
+    if (!gbxTabHandle) {
+        gbxTabHandle = gbxOpenTab(pageUrl);
+        if (!gbxTabHandle) return false;
+    }
+
+    if (await gbxAwaitReady()) {
+        gbxUnavailableUntil = 0;
+        return true;
+    }
+
+    // No heartbeat. The tab may exist but have had no script injected into it, in which case it
+    // will never come good on its own and waiting longer is pointless -- discard it and open a
+    // fresh one once. (Contributor's suggestion, from hitting exactly this on Firefox + TM.)
+    try { xfpdCloseTabHandle(gbxTabHandle); } catch (e) {}
+    gbxTabHandle = gbxOpenTab(pageUrl);
+    if (gbxTabHandle && await gbxAwaitReady()) {
+        gbxUnavailableUntil = 0;
+        return true;
+    }
+
+    // Still nothing after a clean retry: most likely a Cloudflare interstitial that needs a human.
+    // Leave this second tab open -- it is where they would solve it, and the next attempt after the
+    // backoff will find it alive.
+    gbxUnavailableUntil = Date.now() + GBX_BREAKER_MS;
+    return false;
+}
+
+// Sends one API path through the helper tab. Serialized: exactly one bridge request is in flight at
+// a time, which keeps the handshake race-free (a shared queue would need a read-modify-write on a
+// single GM key) and keeps the Goonbox API calls sequential. Resolves to {ok, status, body} or null.
+function goonboxBridgeGet(path, pageUrl) {
+    const run = async () => {
+        if (!goonboxBridgePathAllowed(path)) return null;
+        if (!(await gbxEnsureTab(pageUrl))) return null;
+
+        const id = `${Date.now()}_${++gbxSeq}`;
+        gbxResMirror = '';
+        gbxSet(GBX_K_RES, '');
+        gbxSet(GBX_K_REQ, JSON.stringify({ id, path, t: Date.now() }));
+
+        const deadline = Date.now() + GBX_REQ_TIMEOUT_MS;
+        while (Date.now() < deadline) {
+            await gbxSleep(GBX_POLL_MS);
+
+            // Listener mirror first -- on Firefox + Tampermonkey the polled read never updates.
+            let res = null;
+            for (const raw of [gbxResMirror, gbxGet(GBX_K_RES, '')]) {
+                try {
+                    const p = JSON.parse(String(raw || ''));
+                    if (p && p.id === id) { res = p; break; }
+                } catch (e) {}
+            }
+            if (res) return res;
+
+            // Tab was closed or crashed mid-request; no point waiting out the full deadline.
+            if (!gbxBridgeAlive()) break;
+        }
+        return null;
+    };
+
+    // Count in, cancel any pending close, run, count out, then re-arm only if nothing else is
+    // outstanding. Incrementing here rather than inside run() is deliberate: the request is queued
+    // from this moment, so the tab must survive until the chain drains, not just until the
+    // currently-executing run() returns.
+    gbxInFlight++;
+    gbxCancelIdleTimer();
+
+    const settle = () => {
+        gbxInFlight = Math.max(0, gbxInFlight - 1);
+        gbxMaybeArmIdleTimer();
+    };
+
+    gbxChain = gbxChain.catch(() => {}).then(run);
+    const p = gbxChain;
+    p.then(settle, settle);
+    return p;
+}
+
+// Debug switch: force every Goonbox API call down the bridge path even when the direct request
+// succeeds. From the devtools console on a SimpCity tab:
+//
+//     localStorage.setItem('xfpd_gbx_force_bridge', 'true')   // enable
+//     localStorage.removeItem('xfpd_gbx_force_bridge')        // disable
+//
+// localStorage rather than GM storage because `GM_setValue` does not exist in the page console --
+// the GM_* functions live only inside the userscript sandbox, so they cannot be called from
+// devtools. The flag is read exclusively in the SimpCity tab (the helper tab never consults it), so
+// page-origin storage is sufficient. GM storage is still honoured as well, for anyone setting it
+// through Tampermonkey's Storage tab.
+//
+// This exists because the 403 the bridge was built for has not reproduced in **any** configuration
+// across six test runs (Chrome+TM, Firefox+TM, Firefox+VM). With the direct request always
+// succeeding, not one line of the bridge executes against the real site, so the feature cannot be
+// validated by ordinary testing at all. Forcing the path exercises tab open -> marker -> same-origin
+// fetch -> handshake end to end, independently of whether the symptom reproduces.
+//
+// Off unless explicitly enabled, and it only ever *adds* an attempt -- with the flag set, a failed
+// bridge still falls through to whatever the direct call returned, so enabling it cannot make a
+// download fail that would otherwise have worked.
+const GBX_K_FORCE = 'xfpd_gbx_force_bridge';
+
+function gbxForceEnabled() {
+    // Page-origin storage first, since that is the one reachable from devtools.
+    try {
+        const v = localStorage.getItem(GBX_K_FORCE);
+        if (v !== null && String(v).toLowerCase() === 'true') return true;
+    } catch (e) {}
+    try {
+        const v = gbxGet(GBX_K_FORCE, false);
+        if (v === true || String(v).toLowerCase() === 'true') return true;
+    } catch (e) {}
+    return false;
+}
+
+// One Goonbox API call: direct first, bridge second. Returns parsed JSON, or null if both failed.
+// `pageUrl` is the real Goonbox page being resolved: it is both the Referer for the direct request
+// and, with a marker appended, the URL the helper tab is opened on.
+async function goonboxApiJson(http, path, pageUrl, postId) {
+    const referer = pageUrl;
+    const say = (msg) => {
+        try { log.host.info(postId, msg, 'goonbox.cr'); } catch (e) {}
+    };
+    const parse = (s) => {
+        try {
+            const j = JSON.parse(String(s || ''));
+            return (j && typeof j === 'object') ? j : null;
+        } catch (e) { return null; }
+    };
+
+    let status = 0;
+    let source = '';
+    try {
+        const r = await http.get(
+            `${GOONBOX_ORIGIN}${path}`,
+            {},
+            { Referer: referer || `${GOONBOX_ORIGIN}/`, Accept: 'application/json' },
+            'text',
+        );
+        status = Number((r && r.status) || 0) || 0;
+        source = String((r && r.source) || '');
+    } catch (e) {}
+
+    const direct = (status && status < 400) ? parse(source) : null;
+    const forced = gbxForceEnabled();
+
+    if (direct && !forced) return direct;
+
+    // Whether the bridge engages has been invisible in the logs until now, which is exactly why six
+    // runs produced no usable evidence about it. Say so, and say why.
+    if (forced) {
+        say(`::Bridge forced (debug flag)::: ${path}`);
+    } else {
+        // 403 from Cloudflare, an empty body, or an HTML challenge page that will not parse as JSON
+        // -- all mean the same thing here, so retry same-origin rather than telling them apart.
+        say(`::API direct failed (${status || 'no response'}) -> bridge::: ${path}`);
+    }
+
+    const viaBridge = await goonboxBridgeGet(path, pageUrl);
+
+    if (viaBridge && viaBridge.ok) {
+        const j = parse(viaBridge.body);
+        if (j) {
+            say(`::Bridge OK (${viaBridge.status})::: ${path}`);
+            return j;
+        }
+        say(`::Bridge returned ${viaBridge.status} but body was not JSON::: ${path}`);
+    } else {
+        say(`::Bridge failed (${viaBridge ? viaBridge.status : 'no response'})::: ${path}`);
+    }
+
+    // Forcing must never be able to break a working download: fall back to the direct result.
+    if (direct) return direct;
+
+    return null;
+}
+
+// --- helper-tab side (runs only on goonbox.cr) ---
+// Only serves in a tab *we* opened, identified by the marker in the URL. A user browsing
+// goonbox.cr normally runs this script too (the @match is origin-wide) but must not silently
+// become a bridge for it.
+function gbxIsHelperTab() {
+    try {
+        return new URLSearchParams(location.search).get(GBX_MARKER_KEY) === GBX_MARKER_VAL;
+    } catch (e) {
+        return false;
+    }
+}
+
+function goonboxBridgeServe() {
+    if (!gbxIsHelperTab()) return;
+
+    let lastId = '';
+    let busy = false;
+
+    const beat = () => gbxSet(GBX_K_READY, Date.now());
+    beat();
+    setInterval(beat, GBX_HEARTBEAT_MS);
+
+    const handle = async (raw) => {
+        if (busy) return;
+
+        let req = null;
+        try { req = JSON.parse(String(raw || '')); } catch (e) { req = null; }
+        if (!req || !req.id || req.id === lastId) return;
+
+        lastId = req.id;
+        busy = true;
+
+        const reply = (payload) => {
+            try { gbxSet(GBX_K_RES, JSON.stringify({ id: req.id, ...payload })); } catch (e) {}
+        };
+
+        try {
+            // Re-check here and not only on the requesting side: this tab is the one holding the
+            // cookies, so it is the only place the restriction actually protects anything.
+            if (!goonboxBridgePathAllowed(req.path)) {
+                reply({ ok: false, status: 0, body: '' });
+                return;
+            }
+
+            // Cloudflare may still be settling in a tab that has only just loaded, so a single
+            // attempt is not enough to conclude the cookies are unusable. Retry a few times, but
+            // only while the answer still looks like a challenge or a transport failure -- a clean
+            // 404 is a real answer and is returned immediately.
+            let last = { ok: false, status: 0, body: '' };
+            for (let attempt = 1; attempt <= GBX_FETCH_ATTEMPTS; attempt++) {
+                try {
+                    const r = await fetch(`${GOONBOX_ORIGIN}${req.path}`, {
+                        credentials: 'include',
+                        headers: { Accept: 'application/json' },
+                    });
+                    const body = await r.text();
+                    last = { ok: !!r.ok, status: Number(r.status) || 0, body };
+                } catch (e) {
+                    last = { ok: false, status: 0, body: '' };
+                }
+
+                let parsed = null;
+                try { parsed = JSON.parse(String(last.body || '')); } catch (e) { parsed = null; }
+                if (last.ok && parsed && typeof parsed === 'object') break;
+                if (last.status && last.status !== 403 && last.status !== 429 && last.status < 500) break;
+
+                if (attempt < GBX_FETCH_ATTEMPTS) await gbxSleep(GBX_FETCH_RETRY_MS);
+            }
+
+            reply(last);
+        } catch (e) {
+            reply({ ok: false, status: 0, body: '' });
+        } finally {
+            busy = false;
+        }
+    };
+
+    // Listener first: on Firefox + Tampermonkey the poll below never observes the SimpCity tab's
+    // write at all, because it only ever reads this tab's own cached copy.
+    if (xfpdAddValueChangeListener) {
+        try {
+            xfpdAddValueChangeListener(GBX_K_REQ, (name, oldV, newV) => { handle(newV); });
+        } catch (e) {}
+    }
+
+    // Polling retained deliberately: it is what works on the configurations that already worked,
+    // and `lastId` makes double-delivery a no-op.
+    setInterval(() => { handle(gbxGet(GBX_K_REQ, '')); }, GBX_POLL_MS);
+}
 
 
 // Bunkr/Cloudflare: best-effort warm-up to let the browser complete a JS-only CF interstitial ("Just a moment...").
@@ -785,6 +1406,18 @@ const h = {
    */
     fnNoExt: path => path.trim().split('.').reverse().slice(1).reverse().join('.'),
     /**
+   * Extension without the dot, or '' if there isn't one. Counterpart to fnNoExt.
+   * This was referenced by the duplicate-filename path but never actually defined, so any post with
+   * two same-named files threw "h.extension is not a function" and killed the download.
+   * @param path
+   * @returns {string}
+   */
+    extension: (path) => {
+        const base = String(path || '').trim().split('/').pop();
+        const m = /\.([A-Za-z0-9]{1,8})$/.exec(base);
+        return m && m[1] ? m[1] : '';
+    },
+    /**
    * @param path
    * @returns {unknown}
    */
@@ -993,6 +1626,10 @@ const h = {
                 };
                 const withCredentials = !!(hdrs && Object.prototype.hasOwnProperty.call(hdrs, '__xfpd_withCredentials') && hdrs.__xfpd_withCredentials);
                 try { if (hdrs && Object.prototype.hasOwnProperty.call(hdrs, '__xfpd_withCredentials')) delete hdrs.__xfpd_withCredentials; } catch (e) {}
+                // Opt-in deadline. Without one a request that connects but never answers leaves this
+                // promise pending forever, which wedges the whole resolution loop (no error, no retry).
+                const timeoutMs = Number((hdrs && hdrs.__xfpd_timeout) || 0) || 0;
+                try { if (hdrs && Object.prototype.hasOwnProperty.call(hdrs, '__xfpd_timeout')) delete hdrs.__xfpd_timeout; } catch (e) {}
 
                 request = http({
                     url,
@@ -1001,6 +1638,13 @@ const h = {
                     data,
                     headers: hdrs,
                     ...(withCredentials ? { withCredentials: true, anonymous: false } : {}),
+                    ...(timeoutMs ? { timeout: timeoutMs } : {}),
+                    // Resolve empty rather than reject: callers all read `(r && r.source) || ''`, so a
+                    // timed-out step degrades into "no data" and the resolver moves on to its fallback.
+                    ontimeout: () => {
+                        try { callbacks && callbacks.onTimeout && callbacks.onTimeout(); } catch (e) {}
+                        resolve({ source: '', request, status: 0, dom: null, responseHeaders, finalUrl: '', timedOut: true });
+                    },
                     onreadystatechange: response => {
                         if (response.readyState === 2) {
                             responseHeaders = response.responseHeaders;
@@ -2365,34 +3009,78 @@ const resolvers = [
     [[/kemono.cr\/data/], url => url],
     [
         [/goonbox\.cr\/img\//],
-        async (url, http) => {
+        async (url, http, spoilers, postId) => {
             const id = url.split('/').pop().split('?')[0];
             const fallback = goonboxThumbByUrl.get(url.replace(/\?.*/, '').replace(/\/$/, '')) || null;
 
-            const { source } = await http.get(
-                `https://goonbox.cr/api/images/${id}`,
-                {},
-                { Referer: url, Accept: 'application/json' },
-                'text',
-            );
+            // Direct request first, same-origin bridge tab only if Cloudflare rejects it -- see
+            // goonboxApiJson.
+            const data = await goonboxApiJson(http, `/api/images/${id}`, url, postId);
 
-            let originalUrl = null;
-            if (source) {
+            // Take the first original_url anywhere in the response rather than pinning to
+            // data.image.original_url. That pin yields undefined the moment Goonbox moves the
+            // field, and the only symptom is a silently lower-resolution file -- observed
+            // 2026-08-06, where the album endpoint (images[].original_url) returned full-res
+            // originals for the very same images this path was quietly downgrading.
+            const findOriginal = (obj, depth = 0) => {
+                if (!obj || typeof obj !== 'object' || depth > 6) return null;
+                if (Array.isArray(obj)) {
+                    for (const it of obj) {
+                        const v = findOriginal(it, depth + 1);
+                        if (v) return v;
+                    }
+                    return null;
+                }
+                for (const k of ['original_url', 'originalUrl', 'original']) {
+                    const v = obj[k];
+                    if (typeof v === 'string' && /^https?:\/\//i.test(v.trim())) return v.trim();
+                }
+                for (const k of Object.keys(obj)) {
+                    const v = findOriginal(obj[k], depth + 1);
+                    if (v) return v;
+                }
+                return null;
+            };
+
+            const originalUrl = findOriginal(data);
+
+            if (!originalUrl) {
+                // Silent downgrade to a thumbnail is the worst failure mode here, so say so.
                 try {
-                    originalUrl = JSON.parse(source)?.image?.original_url || null;
+                    log.host.info(postId, `::No original_url in API response -> thumbnail::: ${url}`, 'goonbox.cr');
                 } catch (e) {}
+                return fallback;
             }
 
-            if (!originalUrl) return fallback;
-
-            // Post-migration, some "original_url" targets 404 even though the medium-res thumbnail
-            // on the same cuckcapital.cr host still exists. Verify before trusting it.
-            try {
-                const check = await http.base('HEAD', originalUrl, {}, { Referer: url }, null, 'text');
-                if (!check.status || check.status >= 400) {
-                    return fallback || originalUrl;
+            // Post-migration, some "original_url" targets genuinely 404 even though the medium-res
+            // thumbnail on the same cuckcapital.cr host still exists, so the original is worth
+            // verifying. But only a definitive "gone" justifies discarding it: a HEAD that is
+            // refused outright (0 / 403 / 405) says nothing about whether the file is there --
+            // plenty of CDN edges simply do not serve HEAD -- and treating that as absent throws
+            // away a perfectly good original. Confirm with a ranged GET before falling back.
+            const probe = async (method, headers) => {
+                try {
+                    const r = await http.base(method, originalUrl, {}, { Referer: url, ...headers }, null, 'text');
+                    return Number((r && r.status) || 0) || 0;
+                } catch (e) {
+                    return 0;
                 }
-            } catch (e) {
+            };
+
+            let status = await probe('HEAD', {});
+            let reachable = status >= 200 && status < 400;
+
+            if (!reachable) {
+                // A refused HEAD is not evidence of absence, so let the ranged GET be the
+                // authority: it is the same method the download itself will use.
+                status = await probe('GET', { Range: 'bytes=0-0' });
+                reachable = status >= 200 && status < 400;
+            }
+
+            if (!reachable) {
+                try {
+                    log.host.info(postId, `::Original unreachable (${status}) -> thumbnail::: ${originalUrl}`, 'goonbox.cr');
+                } catch (e) {}
                 return fallback || originalUrl;
             }
 
@@ -2401,23 +3089,13 @@ const resolvers = [
     ],
     [
         [/goonbox\.cr\/a\//],
-        async (url, http) => {
+        async (url, http, spoilers, postId) => {
             const albumSlug = url.replace(/\?.*/, '').split('/').filter(Boolean).pop();
 
-            const fetchPage = async page => {
-                const { source } = await http.get(
-                    `https://goonbox.cr/api/albums/${albumSlug}/images?page=${page}`,
-                    {},
-                    { Referer: url, Accept: 'application/json' },
-                    'text',
-                );
-                if (!source) return null;
-                try {
-                    return JSON.parse(source);
-                } catch (e) {
-                    return null;
-                }
-            };
+            // Direct request first, same-origin bridge tab only if Cloudflare rejects it -- see
+            // goonboxApiJson. The helper tab is reused across every page of the album.
+            const fetchPage = async page =>
+            await goonboxApiJson(http, `/api/albums/${albumSlug}/images?page=${page}`, url, postId);
 
             const first = await fetchPage(1);
             if (!first || !h.isArray(first.images)) return null;
@@ -2638,9 +3316,15 @@ const resolvers = [
             try {
                 const cleanUrl = String(url || '').split('#')[0];
 
+                // Legacy Bunkr CDN hosts no longer serve files directly: as of 2026-07-28,
+                // cdn*.bunkr.*/<name>.mp4 responds 301 -> bunkr.*/f/<slug>, an HTML page. So these
+                // links still need the metadata + signing flow, and must NOT be treated as final.
+                const isLegacyBunkrCdn = /^https?:\/\/(?:cdn\d*|stream)\.bunkrr?r?\./i.test(cleanUrl);
+
                 // If this already looks like a direct media file URL, keep it (don't call /api/vs).
                 // (CDN links usually include the real filename already.)
                 if (
+                    !isLegacyBunkrCdn &&
                     /\.(?:mp4|m4v|webm|mov|mkv|jpg|jpeg|png|gif|webp|zip|rar|7z|pdf)(?:$|\?)/i.test(cleanUrl) &&
                     !/\/(?:v|f|d)\//i.test(cleanUrl)
                 ) {
@@ -2660,7 +3344,13 @@ const resolvers = [
 // This lets us rename CDN GUID links back to the original filename.
 try {
     const strip = (s) => String(s || '').split('#')[0].split('?')[0];
-    const bases = xfpdBunkrFilterBases([origin, 'https://bunkr.pk', 'https://bunkr.cr']);
+    const bases = xfpdBunkrFilterBases(
+        isLegacyBunkrCdn
+            ? ['https://bunkr.cr', 'https://bunkr.pk']
+            : [origin, 'https://bunkr.pk', 'https://bunkr.cr']
+    );
+    // DIAGNOSTIC (b02): tracing why some /f/ links resolve to nothing and get downloaded as HTML.
+    console.log(`[Bunkr] resolve start: url=${cleanUrl} origin=${origin} id=${id} legacyCdn=${isLegacyBunkrCdn} bases=${JSON.stringify(bases)}`);
 
     for (const base of bases) {
         const base0 = String(base || '').replace(/\/$/, '');
@@ -2677,11 +3367,16 @@ try {
             const dom = viewRes?.dom;
             const viewSource = viewRes?.source || '';
 
+            const cfHit = xfpdLooksLikeCfChallenge(viewSource, dom);
+            console.log(`[Bunkr] view ${viewUrl}: bytes=${viewSource.length} dom=${!!dom} cfChallenge=${cfHit}`);
+
             // If Cloudflare interstitial is active, don't capture a bogus "Just a moment..." title as a filename hint.
-            if (xfpdLooksLikeCfChallenge(viewSource, dom)) continue;
+            if (cfHit) continue;
 
             if (!bunkrDataId) {
                 bunkrDataId = dom?.querySelector?.('[data-file-id]')?.getAttribute?.('data-file-id') || null;
+                console.log(`[Bunkr] data-file-id from ${viewUrl}: ${bunkrDataId || 'NOT FOUND'}`
+                    + (bunkrDataId ? '' : ` (page mentions dl.bunkr link: ${/dl\.bunkr\.[a-z]+\/file\/\d+/i.test(viewSource)})`));
             }
 
             let title =
@@ -2723,7 +3418,10 @@ try {
                 };
 
                 const tryNewApi = async () => {
-                    if (!bunkrDataId) return null;
+                    if (!bunkrDataId) {
+                        console.log('[Bunkr] tryNewApi skipped: no data-file-id was found on any view page');
+                        return null;
+                    }
                     try {
                         const refererUrl = `https://get.bunkrr.su/file/${bunkrDataId}`;
                         const response = await http.post(
@@ -2737,11 +3435,13 @@ try {
                             }
                         );
                         const text = String(response?.source || '');
+                        console.log(`[Bunkr] api _001_v2 id=${bunkrDataId}: bytes=${text.length} head=${text.slice(0, 160)}`);
                         if (!text) return null;
                         const data = JSON.parse(text);
                         if (!data) return null;
 
                         let finalUrl = decodeFinalUrl(data);
+                        console.log(`[Bunkr] decoded final url: ${finalUrl || 'DECODE FAILED'}`);
                         if (!finalUrl || typeof finalUrl !== 'string') return null;
                         finalUrl = finalUrl.trim();
                         if (finalUrl.startsWith('//')) finalUrl = 'https:' + finalUrl;
@@ -2766,11 +3466,15 @@ try {
 
                         return finalUrl;
                     } catch (e) {
+                        console.log(`[Bunkr] tryNewApi threw: ${(e && e.message) || e}`);
                         return null;
                     }
                 };
 
                 const finalURL = await tryNewApi();
+                if (!finalURL) {
+                    console.log(`[Bunkr] UNRESOLVED -> falling back to the page URL, which will download as HTML: ${cleanUrl}`);
+                }
                 return finalURL || cleanUrl;
             } catch (error) {
                 console.error(error?.message || error);
@@ -3186,7 +3890,9 @@ if (page === 1) {
 
         // GoFile no longer uses the static appdata.wt from config.js for /contents.
         // The website now derives a per-request X-Website-Token from the account token
-        // via generateWT() in https://gofile.io/dist/js/wt.obf.js, i.e.:
+        // via generateWT() in https://gofile.io/js/wt.obf.js (moved from /dist/js/ in a
+        // 2026-08-13 site redesign -- the old path now 404s to the SPA shell's index.html,
+        // which silently fails the /generateWT/ source check below), i.e.:
         //   WT = sha256(navigator.userAgent + "::" + navigator.language + "::" + token + "::<time>::<salt>")
         // <time> is NOT a static value -- it's Math.floor(Date.now() / 1000 / 14400) (a
         // 4-hour bucket), recomputed live inside generateWT() itself. <salt> is the one
@@ -3210,7 +3916,7 @@ if (page === 1) {
                     : null;
 
             if (!src) {
-                const { source } = await gmReq('GET', 'https://gofile.io/dist/js/wt.obf.js', null, {}, 'text');
+                const { source } = await gmReq('GET', 'https://gofile.io/js/wt.obf.js', null, {}, 'text');
                 src = source || '';
                 if (!src || !/generateWT/.test(src)) {
                     throw new Error('Could not fetch GoFile wt.obf.js (generateWT).');
@@ -3427,14 +4133,55 @@ if (page === 1) {
 
             const resolved = [];
 
+            // Some /d/ links point directly at a file, not a folder -- /contents/{id} then
+            // returns data.type === 'file' with no data.children. Shared by the root-level
+            // case below and the folder-iteration loop, so the link-picking logic (and the
+            // filename-cache side effect) only lives in one place.
+            const resolveGofileFileLink = obj => {
+                if (!obj) return null;
+
+                const fileId = obj.id || obj.code;
+                const fileName = encodeURIComponent(obj.name || fileId || 'file');
+
+                // Prefer direct/CDN links when available. Do NOT force /download/web/
+                // (web flow can return album HTML).
+                const candidates = [obj.directLink, obj.link, obj.downloadLink].filter(Boolean);
+                const link =
+                    candidates.find(u => /\/download\/direct\//i.test(String(u))) ||
+                    candidates[0] ||
+                    (fileId ? `https://gofile.io/download/web/${fileId}/${fileName}` : null);
+
+                if (link) {
+                    // Preserve original GoFile filename (from API) so we don't rely on URL-encoded path segment.
+                    try {
+                        if (obj.name) {
+                            if (fileId) gofileNameById.set(String(fileId), String(obj.name));
+                            gofileNameByUrl.set(String(link), String(obj.name));
+                        }
+                    } catch (e) {}
+                }
+
+                return link;
+            };
+
             const getChildAlbums = async (props, spoilers) => {
-                if (!props || props.status !== 'ok' || !props.data || !props.data.children) {
+                if (!props || props.status !== 'ok' || !props.data) {
                     return [];
                 }
 
                 const resolved = [];
 
             folderName = props.data.name || folderName;
+
+                if (props.data.type === 'file') {
+                    const link = resolveGofileFileLink(props.data);
+                    if (link) resolved.push(link);
+                    return resolved;
+                }
+
+                if (!props.data.children) {
+                    return [];
+                }
 
                 const files = props.data.children;
 
@@ -3444,26 +4191,8 @@ if (page === 1) {
                 if (!obj) continue;
 
                     if (obj.type === 'file') {
-                    const fileId = obj.id || obj.code;
-                    const fileName = encodeURIComponent(obj.name || fileId || 'file');
-
-                    // Prefer direct/CDN links when available. Do NOT force /download/web/
-                    // (web flow can return album HTML).
-                    const candidates = [obj.directLink, obj.link, obj.downloadLink].filter(Boolean);
-                    let link =
-                        candidates.find(u => /\/download\/direct\//i.test(String(u))) ||
-                        candidates[0] ||
-                        (fileId ? `https://gofile.io/download/web/${fileId}/${fileName}` : null);
-
-                    if (link) {
-                        // Preserve original GoFile filename (from API) so we don't rely on URL-encoded path segment.
-                        try {
-                            if (obj.name) {
-                                if (fileId) gofileNameById.set(String(fileId), String(obj.name));
-                                if (link) gofileNameByUrl.set(String(link), String(obj.name));
-                            }
-                        } catch (e) {}resolved.push(link);
-                    }
+                        const link = resolveGofileFileLink(obj);
+                        if (link) resolved.push(link);
                 } else if (obj.type === 'folder') {
                     const folderId = obj.id || obj.code;
                     if (!folderId) continue;
@@ -4936,14 +5665,25 @@ if (page === 1) {
                 const parts = String(u.pathname || '').split('/').filter(Boolean);
                 return parts.length ? parts[parts.length - 1] : '';
             } catch (e) {
+                // Group 1 is the TLD, group 2 is the slug. This returned m[1] and so yielded
+                // "si"/"gg" as the slug for scheme-less links, which then collapsed every filename
+                // to Filester_si.bin and made them all collide.
                 const m = /filester\.(me|sh|si|gg)\/d\/([^\/?#]+)/i.exec(String(url || ''));
-                return m && m[1] ? m[1] : '';
+                return m && m[2] ? m[2] : '';
             }
         })();
 
         if (!slug) return null;
 
-        const apiBase = 'https://filester.me';
+        // The URL patterns accept .me/.sh/.si/.gg, so follow whichever domain the post actually links
+        // to rather than forcing every API call at .me.
+        const apiBase = (() => {
+            try {
+                const u = new URL(url);
+                if (/^(?:[a-z0-9-]+\.)*filester\.(me|sh|si|gg)$/i.test(u.hostname)) return `https://${u.hostname}`;
+            } catch (e) {}
+            return 'https://filester.me';
+        })();
 
         const mkHeaders = () => ({
             Accept: 'application/json, text/plain, */*',
@@ -4951,6 +5691,7 @@ if (page === 1) {
             Origin: apiBase,
             Referer: url,
             __xfpd_withCredentials: true,
+            __xfpd_timeout: FILESTER_API_TIMEOUT_MS,
         });
 
         const safeJson = (txt) => {
@@ -5193,7 +5934,7 @@ const filesterParseDispositionFilename = (headersRaw) => {
                     'GET',
                     probeUrl,
                     { onResponseHeadersReceieved: () => {} },
-                    { Range: 'bytes=0-0', Referer: `${apiBase}/`, __xfpd_withCredentials: true },
+                    { Range: 'bytes=0-0', Referer: `${apiBase}/`, __xfpd_withCredentials: true, __xfpd_timeout: FILESTER_PROBE_TIMEOUT_MS },
                     null,
                     'text',
                 );
@@ -5235,7 +5976,7 @@ const filesterParseDispositionFilename = (headersRaw) => {
                     'GET',
                     tokenUrl,
                     {},
-                    { Range: 'bytes=0-0', Referer: ref, __xfpd_withCredentials: true },
+                    { Range: 'bytes=0-0', Referer: ref, __xfpd_withCredentials: true, __xfpd_timeout: FILESTER_API_TIMEOUT_MS },
                     null,
                     'text',
                 );
@@ -5258,7 +5999,7 @@ const filesterParseDispositionFilename = (headersRaw) => {
                         'GET',
                         tokenUrl,
                         {},
-                        { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', Referer: ref, __xfpd_withCredentials: true },
+                        { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', Referer: ref, __xfpd_withCredentials: true, __xfpd_timeout: FILESTER_API_TIMEOUT_MS },
                         null,
                         'text',
                     );
@@ -5286,6 +6027,27 @@ const filesterParseDispositionFilename = (headersRaw) => {
             }
         };
 
+        // --- v2 API (current) ---------------------------------------------------------------
+        // Filester came back from its outage on a v2 public API and a new CDN. Everything below this
+        // block talks to the old /api/public/* endpoints, which still answer 200 but hand back a
+        // legacy-shaped payload whose server/download_url combination now 404s -- which is why
+        // downloads were failing with "blocked/tiny response" while resolution looked like it worked.
+        // See filesterResolveV2 for the endpoint shape; it is shared with the album (/f/) path,
+        // which resolves its slugs at download time rather than here.
+        try {
+            const v2 = await filesterResolveV2(http, apiBase, slug, progressCB);
+            if (v2 && v2.url) {
+                // filesterResolveV2 keys its hints off the resolved URL; the original /d/ URL needs
+                // the same name and referer so later lookups on it agree.
+                try { filesterNameByUrl.set(String(url), String(v2.name)); } catch (e) {}
+                try { filesterRefByUrl.set(String(url), String(v2.ref)); } catch (e) {}
+                return v2.url;
+            }
+        } catch (e) {}
+
+        // --- legacy v1 fallback -------------------------------------------------------------
+        // Kept in case v2 is unavailable for a given file or domain. Everything from here down is
+        // the pre-outage flow.
         try {
             if (progressCB) progressCB('[Filester] Fetching metadata...');
             const viewRes = await http.base(
@@ -5336,7 +6098,7 @@ try {
             'GET',
             slugPageUrl,
             {},
-            { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', __xfpd_withCredentials: true },
+            { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', __xfpd_withCredentials: true, __xfpd_timeout: FILESTER_API_TIMEOUT_MS },
             {},
             'text',
         );
@@ -5384,7 +6146,7 @@ try {
             'GET',
             viewPageUrl,
             {},
-            { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', __xfpd_withCredentials: true },
+            { Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', __xfpd_withCredentials: true, __xfpd_timeout: FILESTER_API_TIMEOUT_MS },
             {},
             'text',
         );
@@ -5510,74 +6272,10 @@ try {
             }
         } catch (e) {}
 
-// Prefer the cache /v/ stream URL. The /d/ token often requires a Filester referer (otherwise it returns not_whitelisted).
-        try {
-            if (relViewPath && /^\/v\//i.test(String(relViewPath))) {
-                if (progressCB) progressCB('[Filester] Probing cache stream URL...');
-                const bases = [];
-                // Chrome Tampermonkey downloads are more reliable when starting from filester.me (redirects preserve a Filester referrer).
-                if (!isFF) bases.push(apiBase);
-                bases.push('https://cache6.filester.me');
-                for (let i = 1; i <= 8; i++) if (i !== 6) bases.push(`https://cache${i}.filester.me`);
-                if (isFF) bases.push(apiBase);
-
-                let streamUrl = null;
-                let streamCt = '';
-                let streamSize = 0;
-                let streamHdrName = '';
-
-                for (const base of bases) {
-                    const cand = String(base).replace(/\/$/, '') + String(relViewPath);
-                    const p = await filesterProbe(cand);
-                    if (p && p.ok) {
-                        streamUrl = cand;
-                        streamCt = String(p.contentType || '');
-                        streamSize = Number(p.size || 0) || 0;
-                        streamHdrName = String((p && p.fileName) || '');
-                        break;
-                    }
-                }
-
-                if (streamUrl) {
-                    try { filesterSlugByUrl.set(String(streamUrl), String(slug)); } catch (e) {}
-                    try {
-                        const ref0 = (relViewPath ? `${apiBase}${relViewPath}` : `${apiBase}/d/${slug}`);
-                        if (ref0 && String(ref0).startsWith('http')) {
-                            filesterRefByUrl.set(String(streamUrl), String(ref0));
-                            filesterRefByUrl.set(String(url), String(ref0));
-                            filesterRefByUrl.set(`${apiBase}/d/${slug}`, String(ref0));
-                        }
-                    } catch (e) {}
-                    try { if (!nameHint && streamHdrName) nameHint = String(streamHdrName); } catch (e) {}
-                    const ext = filesterExtFromCt(streamCt);
-                    let finalName = '';
-                    try { if (nameHint) finalName = String(nameHint); } catch (e) {}
-                    if (!finalName) finalName = `Filester_${slug}.${ext || 'bin'}`;
-                    try {
-                        const hasExt = /\.[A-Za-z0-9]{1,8}$/.test(String(finalName || ''));
-                        if (!hasExt && ext) finalName = `${finalName}.${ext}`;
-                    } catch (e) {}
-
-                    try {
-                        filesterNameBySlug.set(String(slug), String(finalName));
-                        filesterNameByUrl.set(String(streamUrl), String(finalName));
-                    try { filesterNameByUrl.set(String(url), String(finalName)); } catch (e) {}
-                    try { filesterNameByUrl.set(`${apiBase}/d/${slug}`, String(finalName)); } catch (e) {}
-                    try { if (relViewPath) filesterNameByUrl.set(`${apiBase}${relViewPath}`, String(finalName)); } catch (e) {}
-
-                    } catch (e) {}
-                    if (streamSize) {
-                        try {
-                            filesterSizeBySlug.set(String(slug), Number(streamSize));
-                            filesterSizeByUrl.set(String(streamUrl), Number(streamSize));
-                        } catch (e) {}
-                    }
-
-                    return streamUrl;
-                }
-            }
-        } catch (e) {}
-
+        // Authoritative and fast: /api/public/download returns the current CDN URL directly (today
+        // an fscN.cdn.cr one). This runs *before* the speculative host sweep below, because that
+        // sweep guesses at which host serves /v/<token> and the new CDN does not use that path at
+        // all -- so it always failed, after burning its whole budget on hosts that never answer.
         try {
             if (progressCB) progressCB('[Filester] Resolving download URL...');
             const dlRes = await http.base(
@@ -5646,6 +6344,78 @@ try {
                     filesterSizeByUrl.set(String(dlUrl), Number(sizeHint));
                 }
                 return dlUrl;
+            }
+        } catch (e) {}
+
+        // Fallback only: probe for a /v/ stream URL by guessing the host. Still worth keeping for
+        // the case where the download API is blocked or rate-limited, and because the /d/ token can
+        // require a Filester referer (otherwise it returns not_whitelisted). Bounded by
+        // FILESTER_PROBE_BUDGET_MS since most candidates are currently dead or black holes.
+        try {
+            if (relViewPath && /^\/v\//i.test(String(relViewPath))) {
+                if (progressCB) progressCB('[Filester] Probing cache stream URL...');
+                const bases = filesterStreamBases(apiBase);
+
+                let streamUrl = null;
+                let streamCt = '';
+                let streamSize = 0;
+                let streamHdrName = '';
+
+                // Hard budget for the whole sweep. The authoritative /api/public/download call above
+                // has already failed if we are here, so this is pure guesswork -- worth a few seconds,
+                // never worth minutes.
+                const probeDeadline = Date.now() + FILESTER_PROBE_BUDGET_MS;
+
+                for (const base of bases) {
+                    if (Date.now() > probeDeadline) break;
+                    const cand = String(base).replace(/\/$/, '') + String(relViewPath);
+                    const p = await filesterProbe(cand);
+                    if (p && p.ok) {
+                        streamUrl = cand;
+                        streamCt = String(p.contentType || '');
+                        streamSize = Number(p.size || 0) || 0;
+                        streamHdrName = String((p && p.fileName) || '');
+                        break;
+                    }
+                }
+
+                if (streamUrl) {
+                    try { filesterSlugByUrl.set(String(streamUrl), String(slug)); } catch (e) {}
+                    try {
+                        const ref0 = (relViewPath ? `${apiBase}${relViewPath}` : `${apiBase}/d/${slug}`);
+                        if (ref0 && String(ref0).startsWith('http')) {
+                            filesterRefByUrl.set(String(streamUrl), String(ref0));
+                            filesterRefByUrl.set(String(url), String(ref0));
+                            filesterRefByUrl.set(`${apiBase}/d/${slug}`, String(ref0));
+                        }
+                    } catch (e) {}
+                    try { if (!nameHint && streamHdrName) nameHint = String(streamHdrName); } catch (e) {}
+                    const ext = filesterExtFromCt(streamCt);
+                    let finalName = '';
+                    try { if (nameHint) finalName = String(nameHint); } catch (e) {}
+                    if (!finalName) finalName = `Filester_${slug}.${ext || 'bin'}`;
+                    try {
+                        const hasExt = /\.[A-Za-z0-9]{1,8}$/.test(String(finalName || ''));
+                        if (!hasExt && ext) finalName = `${finalName}.${ext}`;
+                    } catch (e) {}
+
+                    try {
+                        filesterNameBySlug.set(String(slug), String(finalName));
+                        filesterNameByUrl.set(String(streamUrl), String(finalName));
+                    try { filesterNameByUrl.set(String(url), String(finalName)); } catch (e) {}
+                    try { filesterNameByUrl.set(`${apiBase}/d/${slug}`, String(finalName)); } catch (e) {}
+                    try { if (relViewPath) filesterNameByUrl.set(`${apiBase}${relViewPath}`, String(finalName)); } catch (e) {}
+
+                    } catch (e) {}
+                    if (streamSize) {
+                        try {
+                            filesterSizeBySlug.set(String(slug), Number(streamSize));
+                            filesterSizeByUrl.set(String(streamUrl), Number(streamSize));
+                        } catch (e) {}
+                    }
+
+                    return streamUrl;
+                }
             }
         } catch (e) {}
 
@@ -5749,6 +6519,7 @@ const downloadPost = async (parsedPost, parsedHosts, enabledHostsCB, resolvers, 
     log.post.info(postId, `::Using ${enabledHosts.length} host(s)::: ${enabledHosts.map(h => h.name).join(', ')}`, postNumber);
 
     log.separator(postId);
+    log.post.info(postId, `::Script version::: ${xfpdVersion}`, postNumber);
     log.post.info(postId, `::Preparing download::`, postNumber);
 
     let completed = 0;
@@ -6623,70 +7394,42 @@ if (tmp.length) {
                     } catch (e) {}
                 }
 
-                // Filester: turn short /d/<slug> view URLs into cache /v/<token> stream URLs (no tabs).
-                // Album pages (/f/...) mostly contain only short slugs, which require this token step.
+                // Filester: turn short /d/<slug> view URLs into v2 CDN stream URLs (no tabs).
+                // Album pages (/f/...) only ever yield short slugs, so this is the step that makes
+                // album downloads work at all -- the /d/ link resolver never sees them.
+                //
+                // This used to call the v1 /api/public/download endpoint and build
+                // `${host}/v/${token}` candidates from it. v1 still answers 200, so resolution
+                // looked fine, but every one of those URLs 404s on the current CDN -- which is why
+                // single /d/ links worked from b06 while albums kept retrying fsc1/fsc2/fsc3 and
+                // failing. Resolution now goes through the same v2 resolver as single links.
                 if (isFilester) {
                     try {
                         const uF = new URL(String(url || ''));
                         const isFilesterD = /(^|\.)filester\.(me|sh|si|gg)$/i.test(String(uF.host || '')) && /^\/d\//i.test(String(uF.pathname || ''));
                         if (isFilesterD) {
                             const slug = String(uF.pathname || '').split('/').filter(Boolean).pop() || '';
-                            // Short slugs look like "d8ZdCxc" / "QnUVP6A" etc.
-                            const looksLikeShortSlug = /^[A-Za-z0-9]{6,12}$/.test(slug);
-                            if (looksLikeShortSlug) {
-                                const apiRes = await h.http.base(
-                                    'POST',
-                                    'https://filester.me/api/public/download',
-                                    {},
-                                    {
-                                        Accept: 'application/json, text/plain, */*',
-                                        'Content-Type': 'application/json',
-                                        Origin: 'https://filester.me',
-                                        Referer: `https://filester.me/d/${slug}`,
-                                        __xfpd_withCredentials: true,
-                                    },
-                                    JSON.stringify({ file_slug: slug }),
-                                    'text',
-                                );
+                            // Slugs look like "d8ZdCxc" / "QnUVP6A". The bound is deliberately loose
+                            // -- anything path-shaped under /d/ on a Filester host is a slug, and a
+                            // tight length check would silently skip resolution and save the HTML
+                            // view page instead.
+                            const looksLikeSlug = /^[A-Za-z0-9_-]{4,64}$/.test(slug);
+                            if (looksLikeSlug) {
+                                // Follow whichever Filester domain the post linked to.
+                                const apiBase = `https://${String(uF.host || 'filester.me')}`;
+                                const v2 = await filesterResolveV2(h.http, apiBase, slug);
 
-                                const txt = String((apiRes && apiRes.source) || '');
-                                let j = null;
-                                try { j = JSON.parse(txt); } catch (e) {}
-
-                                let token = '';
-                                try { if (j && typeof j.token === 'string') token = String(j.token).trim(); } catch (e) {}
-                                if (!token) {
-                                    try {
-                                        const rel = j && (j.download_url || j.downloadUrl || j.url);
-                                        if (typeof rel === 'string' && rel.trim()) {
-                                            const m = /\/d\/([^\/?#]+)/i.exec(String(rel));
-                                            if (m && m[1]) token = String(m[1]).trim();
-                                        }
-                                    } catch (e) {}
-                                }
-                                if (!token) {
-                                    const m2 = /"token"\s*:\s*"([^"]+)"/i.exec(txt);
-                                    if (m2 && m2[1]) token = String(m2[1]).trim();
-                                }
-
-                                if (token) {
-                                    const candidates = filesterBuildCandidates(token);
-                                    const streamUrl = (candidates && candidates.length) ? candidates[0] : `https://cache6.filester.me/v/${token}`;
-                                    try { filesterCandidatesByToken.set(String(token), candidates); } catch (e) {}
-                                    try {
-                                        for (const c of (candidates || [])) {
-                                            try { filesterSlugByUrl.set(String(c), String(slug)); } catch (e) {}
-                                            try { filesterRefByUrl.set(String(c), 'https://filester.me/'); } catch (e) {}
-                                        }
-                                    } catch (e) {}
+                                if (v2 && v2.url) {
+                                    const streamUrl = String(v2.url);
                                     if (!filesterNoTabTokenLogged) {
                                         filesterNoTabTokenLogged = true;
-                                        log.post.info(postId, `::Filester slug->token->cache (no tab)::: ${slug} -> ${streamUrl}`, postNumber);
+                                        log.post.info(postId, `::Filester slug->v2 token (no tab)::: ${slug} -> ${streamUrl}`, postNumber);
                                     }
 
-                                    try { filesterSlugByUrl.set(String(streamUrl), String(slug)); } catch (e) {}
-                                    try { filesterRefByUrl.set(String(streamUrl), 'https://filester.me/'); } catch (e) {}
-                                    try { filesterRefByUrl.set(String(url), 'https://filester.me/'); } catch (e) {}
+                                    // filesterResolveV2 already recorded the slug/name/referer for
+                                    // the new URL; the /d/ URL still needs its referer mapped so a
+                                    // later fallback to it uses a Filester referer too.
+                                    try { filesterRefByUrl.set(String(url), String(v2.ref)); } catch (e) {}
                                     url = streamUrl;
                                     try { resource.url = streamUrl; } catch (e) {}
                                 }
@@ -6716,8 +7459,11 @@ if (tmp.length) {
                 if (url.includes('turbocdn.st')){
                     reflink = "https://turbo.cr/"
                 }
-                if (/(?:\bfilester\.(me|sh|si|gg)\b|cache\d+\.filester\.(me|sh|si|gg))/i.test(String(url || ''))){
-                    reflink = "https://filester.me/"
+                if (isFilesterUrl(url)){
+                    // Prefer the exact /d/ page the token was issued against; the CDN accepts any
+                    // Filester referer, but a v2 stream URL is not on a filester.* host at all, so
+                    // the old hostname test never fired for it.
+                    reflink = String(filesterRefByUrl.get(String(url)) || "https://filester.me/")
                 }
 
 
@@ -7711,7 +8457,7 @@ const isView = /https?:\/\/(?:www\.)?filester\.(me|sh|si|gg)\/d\//i.test(String(
                         }
 
                         // Filester: prefer the real filename (from view page / API hints). Only fall back to a safe slug-based name when needed.
-                        if (/(?:^|https?:\/\/)(?:cache\d+\.)?filester\.(me|sh|si|gg)\/(?:d|v)\//i.test(String(url || ''))) {
+                        if (isFilesterUrl(url)) {
                             try {
                                 let slug0 = '';
                                 const m = /https?:\/\/(?:www\.)?filester\.(me|sh|si|gg)\/d\/([^\/?#]+)/i.exec(String((resource && resource.original) || ''));
@@ -7886,6 +8632,17 @@ const isView = /https?:\/\/(?:www\.)?filester\.(me|sh|si|gg)\/d\//i.test(String(
                 const intervalId = setInterval(async () => {
                     const p = requestProgress.find(r => r.url === progressKey);
                     if (!p) return;
+
+                    // Large files switch to DIRECT mid-download: that aborts this request and hands
+                    // off to GM_download. request.abort() does not reliably fire onload/onerror once
+                    // a blob response is buffered (see the GoFile duplicate-save fix), so nothing
+                    // clears this interval. Without the guard the watchdog then reports a false
+                    // ::Stalled/Failed:: for a download that actually succeeded, and increments the
+                    // counter a second time -- the DIRECT onload already counts it, giving 3/2.
+                    if (switchedToDirect) {
+                        clearInterval(p.intervalId);
+                        return;
+                    }
 
                     if (p.old === p.new) {
                         const rr = requests.find(r => r.url === progressKey);
@@ -8304,6 +9061,18 @@ const selectedPosts = [];
     // there, so bail out immediately rather than doing pointless work (redgifs token fetch,
     // style injection) on GoFile's own pages.
     try { if (/(^|\.)gofile\.io$/i.test(location.hostname)) return; } catch (e) {}
+
+    // Same deal for goonbox.cr, except this tab has a job to do: it is the helper tab opened by
+    // goonboxBridgeGet, and it is the only context where fetch() carries Goonbox's first-party
+    // cookies. Serve the bridge, then bail out of the forum-post logic exactly as above. Users who
+    // simply browse goonbox.cr also land here -- the bridge just idles, waiting for a request that
+    // never comes, until the tab is closed.
+    try {
+        if (/(^|\.)goonbox\.cr$/i.test(location.hostname)) {
+            try { goonboxBridgeServe(); } catch (e) {}
+            return;
+        }
+    } catch (e) {}
 
     window.addEventListener('beforeunload', e => {
         if (processing.find(p => p.processing)) {


### PR DESCRIPTION
Ports sc-postdl's beta accumulation (3.21.b02-b16) to this build.

Filester:
- Migrated off the retired v1 API to the v2 public API -- v1 was dead, so every Filester download here was broken; this fixes it
- Album (/f/) files now route through the same v2 resolver as single links
- Stop resolution stalling on black-holed CDN hosts

GoFile:
- Fixed wt.obf.js fetch after GoFile's site redesign moved it off /dist/js/ (was silently breaking every GoFile resolution)
- Handle /d/ links that point directly at a file instead of a folder

Goonbox:
- New same-origin bridge tab works around Cloudflare blocking first-party cookies from the SimpCity tab's API calls (403s on Firefox)
- Bridge handshake delivered via GM_addValueChangeListener
- Force-bridge debug flag, settable from devtools, plus activity logging
- Helper tab opens the content URL (not the bare origin) and no longer closes mid-request via the idle-close timer
- Stop silently downgrading /img/ links to thumbnails

Bunkr:
- Stop treating legacy CDN links as final
- Log why /f/ links fail to resolve

Misc:
- Stall watchdog no longer fires after a DIRECT switch
- Script version logged once per post run, so a pasted log identifies its own build